### PR TITLE
fix(release): correct tag format for goreleaser

### DIFF
--- a/release/release-please-config.json
+++ b/release/release-please-config.json
@@ -2,7 +2,6 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "package-name": "fresh",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
This PR fixes the release process by removing the 'package-name' from the release-please configuration. This ensures that git tags are created in the format 'vX.Y.Z', which is compatible with GoReleaser's semantic version parsing.