### PR TITLE
fix: Correct GoReleaser config for proper archiving

### DIFF
--- a/release/.goreleaser.yml
+++ b/release/.goreleaser.yml
@@ -19,12 +19,6 @@ builds:
     main: ./cmd/fresh
     binary: fresh
 
-    archive:
-      format: tar.gz
-      format_overrides:
-        - goos: windows
-          format: zip
-
     # Build for multiple platforms
     goos:
       - linux


### PR DESCRIPTION
This PR fixes the .goreleaser.yml file to allow the release process to complete successfully, enabling correct asset generation for Homebrew.