### PR TITLE
fix: Update goreleaser to use homebrews

### DIFF
--- a/release/.goreleaser.yml
+++ b/release/.goreleaser.yml
@@ -143,7 +143,7 @@ release:
 
     **Full Changelog**: https://github.com/{{ .Env.GITHUB_REPOSITORY_OWNER }}/fresh/compare/{{ .PreviousTag }}...{{.Tag}}
 
-brews:
+homebrews:
   - name: fresh
     repository:
       owner: jsmenzies


### PR DESCRIPTION
This PR updates the .goreleaser.yml to use the 'homebrews' key instead of the deprecated 'brews' key.