### PR TITLE
ci: Pass HOMEBREW_TAP_TOKEN to GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,5 @@ jobs:
           args: release --clean -f release/.goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
This PR updates the release workflow to correctly pass the HOMEBREW_TAP_TOKEN secret to the GoReleaser action, which is required to publish to the Homebrew tap.