### PR TITLE
fix: Configure release-please for main branch and changelog path

### DIFF
--- a/release/release-please-config.json
+++ b/release/release-please-config.json
@@ -2,6 +2,8 @@
   "packages": {
     ".": {
       "release-type": "go",
+      "primary-branch": "main",
+      "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
This PR configures release-please to use 'main' as the primary branch for changelog generation and sets the changelog path to 'CHANGELOG.md'. This should prevent duplicate changelog entries and ensure proper release PR generation.