### PR TITLE
fix: Set Homebrew formula directory in GoReleaser

### DIFF
--- a/release/.goreleaser.yml
+++ b/release/.goreleaser.yml
@@ -149,6 +149,7 @@ brews:
       owner: jsmenzies
       name: homebrew-fresh
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
     commit_author:
       name: James Menzies
       email: bot@goreleaser.com


### PR DESCRIPTION
This PR updates the .goreleaser.yml to explicitly set the Homebrew formula directory to 'Formula/'. This will ensure that GoReleaser updates the formula in the correct location within the tap repository.