### PR TITLE
chore: Add license and update GoReleaser config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 James Menzies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/release/.goreleaser.yml
+++ b/release/.goreleaser.yml
@@ -40,7 +40,7 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
-      - -X main.builtBy=goreleaser
+      - -X main.builtBy=James Menzies
 
     env:
       - CGO_ENABLED=0
@@ -55,11 +55,6 @@ archives:
       {{- .Os }}_
       {{- .Arch }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-
-    # Files to include in archive
-    files:
-      - README.md
-      - LICENSE*
 
 checksum:
   # Generate checksums file
@@ -152,7 +147,7 @@ brews:
     directory: Formula
     commit_author:
       name: James Menzies
-      email: bot@goreleaser.com
+      email: jsmenzies@users.noreply.github.com
     description: "Git repository management CLI tool"
     homepage: "https://github.com/jsmenzies/fresh"
     license: "MIT"


### PR DESCRIPTION
This PR adds a standard MIT license to the repository, which resolves a release-blocking issue. It also updates the .goreleaser.yml file to remove a redundant 'files' block and sets the Homebrew tap commit author email to a no-reply address.