### PR TITLE
fix(goreleaser): Dynamically set builtBy in ldflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          BUILT_BY: ${{ github.event.head_commit.author.name }}


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow and the GoReleaser
configuration to dynamically set the 'builtBy' field in the binaries'
ldflags. The commit author's name is now fetched from the GitHub
context and injected via an environment variable, resolving the need
for a hardcoded value and improving the release process.
