### PR TITLE
feat: enhance pull logic and file status display

### DIFF
--- a/internal/domain/local_state.go
+++ b/internal/domain/local_state.go
@@ -6,18 +6,17 @@ type LocalState interface {
 
 type CleanLocalState struct{}
 
-// DirtyLocalState TODO: potentially add number of new files, modified files, deleted files, etc to display in UI
 type DirtyLocalState struct {
-}
-
-type UntrackedLocalState struct {
+	Added     int
+	Modified  int
+	Deleted   int
+	Untracked int
 }
 
 type LocalStateError struct {
 	Message string
 }
 
-func (CleanLocalState) isLocal()     {}
-func (DirtyLocalState) isLocal()     {}
-func (UntrackedLocalState) isLocal() {}
-func (LocalStateError) isLocal()     {}
+func (CleanLocalState) isLocal() {}
+func (DirtyLocalState) isLocal() {}
+func (LocalStateError) isLocal() {}

--- a/internal/ui/views/common/style.go
+++ b/internal/ui/views/common/style.go
@@ -95,10 +95,14 @@ var localStatusBaseStyle = lipgloss.NewStyle().
 
 var LocalStatusClean = localStatusBaseStyle.
 	Foreground(Green).
-	Render(IconClean + " " + StatusClean)
+	Render(IconClean)
 
-var LocalStatusDirty = localStatusBaseStyle.
-	Foreground(Yellow).
+//Render(IconClean + " " + StatusClean)
+
+var LocalStatusDirtyStyle = localStatusBaseStyle.
+	Foreground(Yellow)
+
+var LocalStatusDirty = LocalStatusDirtyStyle.
 	Render(IconDirty + " " + StatusDirty)
 
 var LocalStatusUntracked = localStatusBaseStyle.
@@ -246,10 +250,13 @@ func FormatPullProgress(spinnerView string, lastLine string) string {
 }
 
 const (
-	IconGit         = "\uF115"
-	IconClock       = "\uF017"
-	IconClean       = "\uF00C"
-	IconDirty       = "\uF071"
+	IconGit   = "\uF115"
+	IconClock = "\uF017"
+	IconClean = "\uF00C"
+	IconDirty = "\uF071"
+	IconGhost = "\uF79F"
+	//IconGhost       = "\uF128"
+	//IconGhost       = "\uF059"
 	IconUntracked   = ""
 	IconDiverged    = "⊘"
 	IconRemoteError = "\U000F04E7"

--- a/internal/ui/views/common/table.go
+++ b/internal/ui/views/common/table.go
@@ -85,11 +85,26 @@ func buildBranchName(branch domain.Branch) string {
 }
 
 func buildLocalStatus(state domain.LocalState) string {
-	switch state.(type) {
+	switch s := state.(type) {
 	case domain.DirtyLocalState:
-		return LocalStatusDirty
-	case domain.UntrackedLocalState:
-		return LocalStatusUntracked
+		var parts []string
+		parts = append(parts, IconDirty)
+
+		if s.Untracked > 0 {
+			parts = append(parts, fmt.Sprintf("%s%d", IconGhost, s.Untracked))
+		}
+		if s.Added > 0 {
+			parts = append(parts, fmt.Sprintf("+%d", s.Added))
+		}
+		if s.Modified > 0 {
+			parts = append(parts, fmt.Sprintf("~%d", s.Modified))
+		}
+		if s.Deleted > 0 {
+			parts = append(parts, fmt.Sprintf("-%d", s.Deleted))
+		}
+
+		text := strings.Join(parts, " ")
+		return LocalStatusDirtyStyle.Render(text)
 	case domain.LocalStateError:
 		return LocalStatusError
 	default:
@@ -179,6 +194,9 @@ func stylePullOutput(lastLine string, exitCode int) string {
 }
 
 func buildLastUpdate(repo domain.Repository) string {
+	if repo.LastCommitTime.IsZero() {
+		return ""
+	}
 	timeAgo := FormatTimeAgo(repo.LastCommitTime)
 	return TimeAgoStyle.Render(IconClock + " " + timeAgo)
 }


### PR DESCRIPTION
- Restrict pull operations to repositories with safe remote states.
- Update 'pull all' command to only target repositories that are behind or diverged.
- Include untracked files in local dirty state analysis.
- Update UI to conditionally display detailed file change counts (+Added ~Modified -Deleted ?Untracked).
- Hide last commit time in UI if it is unknown.
