### PR TITLE
docs: document release process changes and trigger release

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,42 @@
+# Release Process Update
+
+## Summary
+
+Updated the release workflow to use the consolidated Homebrew tap with modern GoReleaser configuration.
+
+## Changes
+
+### GoReleaser Configuration
+- Migrated from deprecated `brews` configuration to `homebrew_casks`
+- Consolidated to a single Homebrew tap: `jsmenzies/homebrew-tap`
+- Removed separate scoop bucket in favor of using the same tap
+- Simplified release artifact distribution
+
+### Workflow Updates  
+- Updated GitHub Actions to use latest versions (actions/setup-go@v6, actions/checkout@v6)
+- Added Renovate for automated dependency updates
+- Configured automated release process via release-please
+
+## Release Flow
+
+To trigger a new release:
+
+1. **Merge changes to `main` branch** with conventional commits:
+   - Use `feat:` for new features (bumps minor version)
+   - Use `fix:` for bug fixes (bumps patch version)  
+   - Use `docs:` or `refactor:` for visible changes (appears in changelog)
+   - Avoid `chore:`, `ci:`, `test:` for hidden/internal changes
+
+2. **Release-please automatically creates a Release PR** when it detects user-facing commits on main
+
+3. **Merge the Release PR** to trigger the actual release:
+   - Creates GitHub release with changelog
+   - GoReleaser builds binaries for all platforms
+   - Publishes to Homebrew tap
+   - Generates checksums and release notes
+
+## Versioning
+
+- Current version: 1.9.2
+- Next version will be determined by commit types since last release
+- Version is tracked in `release/.release-please-manifest.json`


### PR DESCRIPTION
## Summary

This PR documents the release process migration that was implemented in #60 and triggers a new release.

## Background

The previous PR #60 migrated the release configuration from deprecated `brews` to `homebrew_casks` in GoReleaser, but it was marked as `chore:` which is hidden from the changelog. This meant release-please didn't create a release PR.

## Changes

- Added `RELEASE_PROCESS.md` documenting:
  - The migration from `brews` to `homebrew_casks`
  - Consolidation to single Homebrew tap
  - Updated GitHub Actions versions
  - Complete release flow documentation

## Release Flow

**Important**: To trigger releases going forward, use these conventional commit types:

| Commit Type | Visibility | Version Impact |
|------------|-----------|----------------|
| `feat:` | ✅ Visible in changelog | Bumps minor version |
| `fix:` | ✅ Visible in changelog | Bumps patch version |
| `docs:` | ✅ Visible in changelog | Bumps patch version |
| `refactor:` | ✅ Visible in changelog | Bumps patch version |
| `chore:` | ❌ Hidden | No release triggered |
| `ci:` | ❌ Hidden | No release triggered |
| `test:` | ❌ Hidden | No release triggered |

### How Releases Work

1. **Push to main** with visible commit types
2. **Release-please** automatically creates a Release PR
3. **Merge the Release PR** to trigger the actual release with GoReleaser

## Checklist

- [x] Documented release process changes
- [x] Explained conventional commit requirements
- [x] Ready to trigger v1.9.3 release