### PR TITLE
docs: fix homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Fresh uses [Nerd Fonts](https://www.nerdfonts.com/) to render icons. We specific
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew tap jsmenzies/fresh
-brew install fresh
+brew install jsmenzies/tap/fresh
 ```
 
 ### Scoop (Windows)


### PR DESCRIPTION
Update the homebrew install command in README to use the correct tap path: `brew install jsmenzies/tap/fresh`