### PR TITLE
feat: add prune merged branches functionality

### DIFF
--- a/internal/domain/activity.go
+++ b/internal/domain/activity.go
@@ -57,3 +57,43 @@ func (p *PullingActivity) GetAllOutput() string {
 	}
 	return result
 }
+
+type PruningActivity struct {
+	Spinner      spinner.Model
+	Lines        []string
+	DeletedCount int
+	TotalCount   int
+	ExitCode     int
+	Complete     bool
+}
+
+func (PruningActivity) isActivity() {}
+
+func (p *PruningActivity) AddLine(line string) {
+	p.Lines = append(p.Lines, line)
+}
+
+func (p *PruningActivity) GetLastLine() string {
+	if len(p.Lines) == 0 {
+		return ""
+	}
+	return p.Lines[len(p.Lines)-1]
+}
+
+func (p *PruningActivity) MarkComplete(exitCode int, deletedCount int) {
+	p.Complete = true
+	p.ExitCode = exitCode
+	p.DeletedCount = deletedCount
+}
+
+func (p *PruningActivity) GetAllOutput() string {
+	if len(p.Lines) == 0 {
+		return ""
+	}
+
+	var result string
+	for _, line := range p.Lines {
+		result += line + "\n"
+	}
+	return result
+}

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -24,3 +24,22 @@ type pullWorkState struct {
 	lineChan chan string
 	doneChan chan pullCompleteMsg
 }
+
+type pruneWorkState struct {
+	Index    int
+	lineChan chan string
+	doneChan chan pruneCompleteMsg
+}
+
+type pruneLineMsg struct {
+	Index int
+	line  string
+	state *pruneWorkState
+}
+
+type pruneCompleteMsg struct {
+	Index        int
+	exitCode     int
+	Repo         domain.Repository
+	DeletedCount int
+}

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -160,6 +160,18 @@ func buildInfo(repo domain.Repository) string {
 		if !activity.Complete {
 			content = ""
 		}
+	case domain.PruningActivity:
+		if !activity.Complete {
+			lastLine := activity.GetLastLine()
+			truncated := common.TruncateWithEllipsis(lastLine, common.InfoWidth-3)
+			content = common.FormatPullProgress(activity.Spinner.View(), truncated)
+		} else {
+			if activity.DeletedCount == 0 {
+				content = common.PullOutputWarn.Render("No branches to prune")
+			} else {
+				content = common.PullOutputSuccess.Render(fmt.Sprintf("Deleted %d branches", activity.DeletedCount))
+			}
+		}
 	}
 
 	if content == "" {


### PR DESCRIPTION
## Summary

Add ability to remove merged local branches from repositories with real-time progress tracking.

## Features

- Single repo: Press 'b' to prune merged branches on selected repository
- All repos: Press 'ctrl+b' to prune all repositories with merged branches
- Real-time progress: Shows spinner and deleted branch names during operation
- Protected branches: Automatically excludes main, master, develop, dev, production, staging, release
- Safe deletion: Uses 'git branch -d' which skips squashed branches
- Visual feedback: 
  - Green message when branches deleted
  - Yellow message when no branches to prune

## Implementation Details

- Added PruningActivity domain type following existing activity patterns
- Added GetMergedBranches and DeleteBranches git functions
- Protected branches list is configurable via ProtectedBranches variable
- Prevents concurrent operations using existing isBusy check

## Testing

- Build passes
- Tests pass

## Files Changed

- internal/domain/activity.go - Added PruningActivity
- internal/git/git.go - Branch detection and deletion functions  
- internal/ui/views/listing/commands.go - Prune commands
- internal/ui/views/listing/listing.go - Key bindings and handlers
- internal/ui/views/listing/messages.go - Prune message types
- internal/ui/views/listing/table.go - Progress rendering
