### PR TITLE
feat: separate regular merged and squashed branches with different keys

### DIFF
--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -3,14 +3,15 @@ package domain
 import "time"
 
 type Repository struct {
-	Name           string
-	Path           string
-	RemoteURL      string
-	Branch         Branch
-	LocalState     LocalState
-	RemoteState    RemoteState
-	LastCommitTime time.Time
-	Activity       Activity
-	ErrorMessage   string
-	MergedBranches []string
+	Name             string
+	Path             string
+	RemoteURL        string
+	Branch           Branch
+	LocalState       LocalState
+	RemoteState      RemoteState
+	LastCommitTime   time.Time
+	Activity         Activity
+	ErrorMessage     string
+	MergedBranches   []string
+	SquashedBranches []string
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -20,17 +20,18 @@ func BuildRepository(path string) domain.Repository {
 	remoteState := GetStatus(path)
 	lastCommitTime := GetLastCommitTime(path)
 	remoteURL := GetRemoteURL(path)
-	mergedBranches, _ := GetMergedBranches(path, ProtectedBranches)
+	mergedBranches, squashedBranches, _ := GetMergedBranches(path, ProtectedBranches)
 
 	return domain.Repository{
-		Name:           repoName,
-		Path:           path,
-		Branch:         branch,
-		LocalState:     localState,
-		LastCommitTime: lastCommitTime,
-		RemoteURL:      remoteURL,
-		RemoteState:    remoteState,
-		MergedBranches: mergedBranches,
+		Name:             repoName,
+		Path:             path,
+		Branch:           branch,
+		LocalState:       localState,
+		LastCommitTime:   lastCommitTime,
+		RemoteURL:        remoteURL,
+		RemoteState:      remoteState,
+		MergedBranches:   mergedBranches,
+		SquashedBranches: squashedBranches,
 	}
 }
 
@@ -40,7 +41,7 @@ func RefreshRepositoryState(repo *domain.Repository) {
 	repo.RemoteState = GetStatus(repo.Path)
 	repo.LastCommitTime = GetLastCommitTime(repo.Path)
 	repo.RemoteURL = GetRemoteURL(repo.Path)
-	repo.MergedBranches, _ = GetMergedBranches(repo.Path, ProtectedBranches)
+	repo.MergedBranches, repo.SquashedBranches, _ = GetMergedBranches(repo.Path, ProtectedBranches)
 }
 
 func IsGitInstalled() bool {
@@ -304,12 +305,12 @@ func splitOnCROrLF(data []byte, atEOF bool) (advance int, token []byte, err erro
 	return 0, nil, nil
 }
 
-func GetMergedBranches(repoPath string, excludedBranches []string) ([]string, error) {
+func GetMergedBranches(repoPath string, excludedBranches []string) ([]string, []string, error) {
 	cmd := exec.Command("git", "branch", "--merged", "HEAD", "--format=%(refname:short)")
 	cmd.Dir = repoPath
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	currentBranch := ""
@@ -323,15 +324,27 @@ func GetMergedBranches(repoPath string, excludedBranches []string) ([]string, er
 	}
 
 	var mergedBranches []string
+	var squashedBranches []string
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
 	for scanner.Scan() {
 		branch := strings.TrimSpace(scanner.Text())
 		if branch != "" && branch != currentBranch && !excludedMap[branch] {
-			mergedBranches = append(mergedBranches, branch)
+			if isBranchFullyMerged(repoPath, branch) {
+				mergedBranches = append(mergedBranches, branch)
+			} else {
+				squashedBranches = append(squashedBranches, branch)
+			}
 		}
 	}
 
-	return mergedBranches, scanner.Err()
+	return mergedBranches, squashedBranches, scanner.Err()
+}
+
+func isBranchFullyMerged(repoPath string, branch string) bool {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", branch, "HEAD")
+	cmd.Dir = repoPath
+	err := cmd.Run()
+	return err == nil
 }
 
 func DeleteBranches(repoPath string, branches []string, lineCallback func(string)) (exitCode int, deletedCount int) {
@@ -347,6 +360,33 @@ func DeleteBranches(repoPath string, branches []string, lineCallback func(string
 			// Branch not fully merged (e.g., squashed) - skip it
 			if lineCallback != nil {
 				lineCallback(fmt.Sprintf("Skipped: %s (not merged)", branch))
+			}
+			continue
+		}
+
+		deletedCount++
+		if lineCallback != nil {
+			lineCallback(fmt.Sprintf("Deleted: %s", branch))
+		}
+		_ = outputStr
+	}
+
+	return 0, deletedCount
+}
+
+func DeleteSquashedBranches(repoPath string, branches []string, lineCallback func(string)) (exitCode int, deletedCount int) {
+	deletedCount = 0
+
+	for _, branch := range branches {
+		cmd := exec.Command("git", "branch", "-D", branch)
+		cmd.Dir = repoPath
+		output, err := cmd.CombinedOutput()
+		outputStr := strings.TrimSpace(string(output))
+
+		if err != nil {
+			// Force delete should rarely fail, but handle it
+			if lineCallback != nil {
+				lineCallback(fmt.Sprintf("Error: %s", outputStr))
 			}
 			continue
 		}

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -130,3 +130,40 @@ func listenForPruneProgress(state pruneWorkState) tea.Cmd {
 		}
 	}
 }
+
+func performPruneSquashed(index int, repoPath string, branches []string) tea.Cmd {
+	return func() tea.Msg {
+		lineChan := make(chan string, 10)
+		doneChan := make(chan pruneCompleteMsg, 1)
+
+		go func() {
+			deletedCount := 0
+			lineCallback := func(line string) {
+				lineChan <- line
+				if len(line) > 9 && line[:9] == "Deleted: " {
+					deletedCount++
+				}
+			}
+
+			_, deleted := git.DeleteSquashedBranches(repoPath, branches, lineCallback)
+
+			close(lineChan)
+
+			repo := git.BuildRepository(repoPath)
+
+			doneChan <- pruneCompleteMsg{
+				Index:        index,
+				exitCode:     0,
+				Repo:         repo,
+				DeletedCount: deleted,
+			}
+			close(doneChan)
+		}()
+
+		return pruneWorkState{
+			Index:    index,
+			lineChan: lineChan,
+			doneChan: doneChan,
+		}
+	}
+}

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -12,13 +12,15 @@ import (
 )
 
 type listKeyMap struct {
-	refresh      key.Binding
-	updateAll    key.Binding
-	pull         key.Binding
-	pullAll      key.Binding
-	prune        key.Binding
-	pruneAll     key.Binding
-	toggleLegend key.Binding
+	refresh          key.Binding
+	updateAll        key.Binding
+	pull             key.Binding
+	pullAll          key.Binding
+	prune            key.Binding
+	pruneAll         key.Binding
+	pruneSquashed    key.Binding
+	pruneSquashedAll key.Binding
+	toggleLegend     key.Binding
 }
 
 func newListKeyMap() *listKeyMap {
@@ -46,6 +48,14 @@ func newListKeyMap() *listKeyMap {
 		pruneAll: key.NewBinding(
 			key.WithKeys("ctrl+b"),
 			key.WithHelp("ctrl+b", "prune all"),
+		),
+		pruneSquashed: key.NewBinding(
+			key.WithKeys("B"),
+			key.WithHelp("shift+b", "prune squashed"),
+		),
+		pruneSquashedAll: key.NewBinding(
+			key.WithKeys("ctrl+B"),
+			key.WithHelp("ctrl+shift+b", "prune squashed all"),
 		),
 		toggleLegend: key.NewBinding(
 			key.WithKeys("?"),
@@ -189,6 +199,38 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					repo.Activity = pruning
 					cmds = append(cmds, performPrune(i, repo.Path, repo.MergedBranches))
+					cmds = append(cmds, pruning.Spinner.Tick)
+				}
+			}
+			return m, tea.Batch(cmds...)
+
+		case key.Matches(msg, m.Keys.pruneSquashed):
+			if m.Cursor < len(m.Repositories) {
+				repo := &m.Repositories[m.Cursor]
+				if !isBusy(*repo) && canPrune(*repo) && len(repo.SquashedBranches) > 0 {
+					pruning := domain.PruningActivity{
+						Spinner: common.NewPullSpinner(),
+						Lines:   make([]string, 0),
+					}
+					repo.Activity = pruning
+					return m, tea.Batch(
+						performPruneSquashed(m.Cursor, repo.Path, repo.SquashedBranches),
+						pruning.Spinner.Tick,
+					)
+				}
+			}
+
+		case key.Matches(msg, m.Keys.pruneSquashedAll):
+			var cmds []tea.Cmd
+			for i := range m.Repositories {
+				repo := &m.Repositories[i]
+				if !isBusy(*repo) && canPrune(*repo) && len(repo.SquashedBranches) > 0 {
+					pruning := domain.PruningActivity{
+						Spinner: common.NewPullSpinner(),
+						Lines:   make([]string, 0),
+					}
+					repo.Activity = pruning
+					cmds = append(cmds, performPruneSquashed(i, repo.Path, repo.SquashedBranches))
 					cmds = append(cmds, pruning.Spinner.Tick)
 				}
 			}
@@ -341,8 +383,10 @@ func buildFooter() string {
 		"ctrl+r refresh all",
 		"p pull",
 		"ctrl+p pull all",
-		"b prune",
-		"ctrl+b prune all",
+		"b prune merged",
+		"ctrl+b prune merged all",
+		"shift+b prune squashed",
+		"ctrl+shift+b prune squashed all",
 		"? toggle legend",
 		"q quit",
 	}

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -175,13 +175,26 @@ func buildInfo(repo domain.Repository) string {
 	}
 
 	if content == "" {
-		// Check for merged branches first
-		if len(repo.MergedBranches) > 0 {
-			branchText := "branch(es)"
-			if len(repo.MergedBranches) == 1 {
-				branchText = "branch"
+		mergedCount := len(repo.MergedBranches)
+		squashedCount := len(repo.SquashedBranches)
+
+		if mergedCount > 0 || squashedCount > 0 {
+			var parts []string
+			if mergedCount > 0 {
+				branchText := "branches"
+				if mergedCount == 1 {
+					branchText = "branch"
+				}
+				parts = append(parts, common.TextBlue.Render(fmt.Sprintf("%d merged %s", mergedCount, branchText)))
 			}
-			content = common.TextBlue.Render(fmt.Sprintf("%d merged %s can be cleaned", len(repo.MergedBranches), branchText))
+			if squashedCount > 0 {
+				branchText := "branches"
+				if squashedCount == 1 {
+					branchText = "branch"
+				}
+				parts = append(parts, common.LocalStatusDirtyStyle.Render(fmt.Sprintf("%d squashed %s", squashedCount, branchText)))
+			}
+			content = strings.Join(parts, ", ") + " can be cleaned"
 		} else {
 			switch s := repo.RemoteState.(type) {
 			case domain.NoUpstream:


### PR DESCRIPTION
## Summary

Adds separate handling for regular merged branches vs squashed branches with distinct keys and visual indicators.

## Changes

- **Domain**: Added SquashedBranches field to Repository model
- **Git**: Categorizes branches during fetch using ancestry check (git merge-base --is-ancestor)
  - Regular merged: Passes ancestry check (true merge)
  - Squashed: Fails check but appears in git branch --merged
- **Keys**:
  - 'b': Prune regular merged branches (safe, uses -d)
  - 'shift+b': Prune squashed branches (force delete with -D)
  - 'ctrl+b'/'ctrl+shift+b': Apply to all repos
- **UI**: Shows combined message with color coding
  - Blue: "3 merged branches"
  - Yellow: "2 squashed branches"
  - Combined: "3 merged, 2 squashed branches can be cleaned"
- **Footer**: Updated with all prune key combinations

## Safety

- Regular pruning ('b') remains safe with -d flag
- Squashed pruning ('shift+b') requires explicit user action with -D flag
- No accidental data loss from squashed merges

## Testing

- Build passes: ✓
- Tests pass: ✓
