### PR TITLE
feat: show merged branches count in INFO column

### DIFF
--- a/internal/domain/activity.go
+++ b/internal/domain/activity.go
@@ -21,79 +21,47 @@ func (r *RefreshingActivity) MarkComplete() {
 	r.Complete = true
 }
 
+type LineBuffer struct {
+	Lines []string
+}
+
+func (lb *LineBuffer) AddLine(line string) {
+	lb.Lines = append(lb.Lines, line)
+}
+
+func (lb *LineBuffer) GetLastLine() string {
+	if len(lb.Lines) == 0 {
+		return ""
+	}
+	return lb.Lines[len(lb.Lines)-1]
+}
+
 type PullingActivity struct {
+	LineBuffer
 	Spinner  spinner.Model
-	Lines    []string
 	ExitCode int
 	Complete bool
 }
 
 func (PullingActivity) isActivity() {}
 
-func (p *PullingActivity) AddLine(line string) {
-	p.Lines = append(p.Lines, line)
-}
-
-func (p *PullingActivity) GetLastLine() string {
-	if len(p.Lines) == 0 {
-		return ""
-	}
-	return p.Lines[len(p.Lines)-1]
-}
-
 func (p *PullingActivity) MarkComplete(exitCode int) {
 	p.Complete = true
 	p.ExitCode = exitCode
 }
 
-func (p *PullingActivity) GetAllOutput() string {
-	if len(p.Lines) == 0 {
-		return ""
-	}
-
-	var result string
-	for _, line := range p.Lines {
-		result += line + "\n"
-	}
-	return result
-}
-
 type PruningActivity struct {
+	LineBuffer
 	Spinner      spinner.Model
-	Lines        []string
 	DeletedCount int
-	TotalCount   int
 	ExitCode     int
 	Complete     bool
 }
 
 func (PruningActivity) isActivity() {}
 
-func (p *PruningActivity) AddLine(line string) {
-	p.Lines = append(p.Lines, line)
-}
-
-func (p *PruningActivity) GetLastLine() string {
-	if len(p.Lines) == 0 {
-		return ""
-	}
-	return p.Lines[len(p.Lines)-1]
-}
-
 func (p *PruningActivity) MarkComplete(exitCode int, deletedCount int) {
 	p.Complete = true
 	p.ExitCode = exitCode
 	p.DeletedCount = deletedCount
-}
-
-func (p *PruningActivity) GetAllOutput() string {
-	if len(p.Lines) == 0 {
-		return ""
-	}
-
-	var result string
-	for _, line := range p.Lines {
-		result += line + "\n"
-	}
-	return result
 }

--- a/internal/domain/repository.go
+++ b/internal/domain/repository.go
@@ -11,5 +11,4 @@ type Repository struct {
 	RemoteState    RemoteState
 	LastCommitTime time.Time
 	Activity       Activity
-	ErrorMessage   string
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -32,14 +32,6 @@ func BuildRepository(path string) domain.Repository {
 	}
 }
 
-func RefreshRepositoryState(repo *domain.Repository) {
-	repo.Branches = BuildBranches(repo.Path, ProtectedBranches)
-	repo.LocalState = HasModifiedFiles(repo.Path)
-	repo.RemoteState = GetStatus(repo.Path)
-	repo.LastCommitTime = GetLastCommitTime(repo.Path)
-	repo.RemoteURL = GetRemoteURL(repo.Path)
-}
-
 func IsGitInstalled() bool {
 	cmd := exec.Command("git", "--version")
 	err := cmd.Run()

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -10,13 +10,7 @@ func performRefresh(index int, repoPath string) tea.Cmd {
 	return func() tea.Msg {
 		repo := git.BuildRepository(repoPath)
 
-		err := git.RefreshRemoteStatusWithFetch(&repo)
-		if err != nil {
-			repo.ErrorMessage = err.Error()
-		} else {
-			repo.ErrorMessage = ""
-		}
-
+		git.RefreshRemoteStatusWithFetch(&repo)
 		repo.RemoteState = git.GetStatus(repoPath)
 
 		return RepoUpdatedMsg{

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -108,7 +108,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if !isBusy(*repo) && shouldPull(*repo) {
 					pulling := domain.PullingActivity{
 						Spinner: common.NewPullSpinner(),
-						Lines:   make([]string, 0),
 					}
 					repo.Activity = pulling
 					cmds = append(cmds, performPull(i, repo.Path))
@@ -124,7 +123,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if !isBusy(*repo) && len(repo.Branches.Merged) > 0 {
 					pruning := domain.PruningActivity{
 						Spinner: common.NewPullSpinner(),
-						Lines:   make([]string, 0),
 					}
 					repo.Activity = pruning
 					cmds = append(cmds, performPrune(i, repo.Path, repo.Branches.Merged))


### PR DESCRIPTION
- Remove unused ErrorMessage field from Repository struct
- Remove unused TotalCount field from PruningActivity struct
- Remove unused GetAllOutput() methods from activity types
- Remove unused RefreshRepositoryState() function from git package
- Extract shared LineBuffer struct with AddLine() and GetLastLine() methods
- Embed LineBuffer in PullingActivity and PruningActivity to eliminate duplication
- Remove redundant Lines initialization from struct literals

Reduces code complexity and eliminates 11 lines of duplicate code.