### PR TITLE
refactor: add context timeouts to git commands and optimize branch filtering

### DIFF
--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -9,9 +9,7 @@ import (
 func performRefresh(index int, repoPath string) tea.Cmd {
 	return func() tea.Msg {
 		repo := git.BuildRepository(repoPath)
-
 		git.RefreshRemoteStatusWithFetch(&repo)
-		repo.RemoteState = git.GetStatus(repoPath)
 
 		return RepoUpdatedMsg{
 			Repo:  repo,


### PR DESCRIPTION
## Summary
- Add context-based timeouts to all git commands to prevent hanging operations
- Default timeout of 30 seconds for most operations, 120s for pull
- Optimize `FilterMergedBranches` to use a single git call instead of N calls
- Simplify error handling with switch statement in `GetStatus`
- Remove redundant `RefreshRemoteStatusWithFetch` call in listing commands