### PR TITLE
refactor: move git operation timeouts to config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,16 @@
 package config
 
+import "time"
+
+type TimeoutConfig struct {
+	Default time.Duration
+	Pull    time.Duration
+	Fetch   time.Duration
+}
+
 type Config struct {
 	ProtectedBranches []string
+	Timeout           TimeoutConfig
 }
 
 func DefaultConfig() *Config {
@@ -14,6 +23,11 @@ func DefaultConfig() *Config {
 			"production",
 			"staging",
 			"release",
+		},
+		Timeout: TimeoutConfig{
+			Default: 30 * time.Second,
+			Pull:    2 * time.Minute,
+			Fetch:   1 * time.Minute,
 		},
 	}
 }

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -78,12 +78,8 @@ func performPrune(index int, repoPath string, branches []string) tea.Cmd {
 		doneChan := make(chan pruneCompleteMsg, 1)
 
 		go func() {
-			deletedCount := 0
 			lineCallback := func(line string) {
 				lineChan <- line
-				if len(line) > 9 && line[:9] == "Deleted: " {
-					deletedCount++
-				}
 			}
 
 			_, deleted := git.DeleteBranches(repoPath, branches, lineCallback)


### PR DESCRIPTION
Move all timeout constants into config package for centralized management. Each git function now internally accesses timeouts via config.DefaultConfig().

**Timeout Values:**
- Default: 30s (most operations)
- Fetch: 1 minute
- Pull: 2 minutes

**Benefits:**
- Centralized timeout configuration
- Simplified API (no timeout parameters)
- Consistent timeout handling