### PR TITLE
Harden PR sync snapshot and trim redundant listing tests

### DIFF
--- a/internal/git/pull_requests_test.go
+++ b/internal/git/pull_requests_test.go
@@ -1,0 +1,158 @@
+package git
+
+import "testing"
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func makePRNode(opts ...func(*gqlPullRequestNode)) gqlPullRequestNode {
+	node := gqlPullRequestNode{}
+	for _, opt := range opts {
+		opt(&node)
+	}
+	return node
+}
+
+func withDraft() func(*gqlPullRequestNode) {
+	return func(node *gqlPullRequestNode) {
+		node.IsDraft = true
+	}
+}
+
+func withMergeState(value string) func(*gqlPullRequestNode) {
+	return func(node *gqlPullRequestNode) {
+		node.MergeStateStatus = strPtr(value)
+	}
+}
+
+func withReviewDecision(value string) func(*gqlPullRequestNode) {
+	return func(node *gqlPullRequestNode) {
+		node.ReviewDecision = strPtr(value)
+	}
+}
+
+func withRollup(rollup gqlStatusCheckRollup) func(*gqlPullRequestNode) {
+	return func(node *gqlPullRequestNode) {
+		node.Commits.Nodes = []struct {
+			Commit struct {
+				StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
+			} `json:"commit"`
+		}{
+			{
+				Commit: struct {
+					StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
+				}{StatusCheckRollup: &rollup},
+			},
+		}
+	}
+}
+
+func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		node gqlPullRequestNode
+		want string
+	}{
+		{
+			name: "draft is blocked",
+			node: makePRNode(
+				withDraft(),
+				withReviewDecision("APPROVED"),
+			),
+			want: "blocked",
+		},
+		{
+			name: "merge blocked is blocked",
+			node: makePRNode(
+				withMergeState("BLOCKED"),
+			),
+			want: "blocked",
+		},
+		{
+			name: "failing checks are blocked",
+			node: makePRNode(
+				withRollup(gqlStatusCheckRollup{State: "FAILURE"}),
+			),
+			want: "blocked",
+		},
+		{
+			name: "changes requested is blocked",
+			node: makePRNode(
+				withReviewDecision("CHANGES_REQUESTED"),
+			),
+			want: "blocked",
+		},
+		{
+			name: "pending checks is checks",
+			node: makePRNode(
+				withRollup(gqlStatusCheckRollup{State: "PENDING"}),
+			),
+			want: "checks",
+		},
+		{
+			name: "approved with no pending checks is ready",
+			node: makePRNode(
+				withReviewDecision("APPROVED"),
+			),
+			want: "ready",
+		},
+		{
+			name: "default requires review",
+			node: makePRNode(),
+			want: "review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyMyPullRequest(tt.node)
+			if got != tt.want {
+				t.Fatalf("classifyMyPullRequest() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyMyPullRequest_ContextDrivenPendingChecks(t *testing.T) {
+	t.Parallel()
+
+	node := makePRNode(
+		withRollup(gqlStatusCheckRollup{
+			State: "SUCCESS",
+			Contexts: struct {
+				Nodes []gqlStatusContextNode `json:"nodes"`
+			}{
+				Nodes: []gqlStatusContextNode{{Status: "IN_PROGRESS"}},
+			},
+		}),
+	)
+
+	got := classifyMyPullRequest(node)
+	if got != "checks" {
+		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, "checks")
+	}
+}
+
+func TestClassifyMyPullRequest_ContextDrivenFailingChecks(t *testing.T) {
+	t.Parallel()
+
+	node := makePRNode(
+		withRollup(gqlStatusCheckRollup{
+			State: "SUCCESS",
+			Contexts: struct {
+				Nodes []gqlStatusContextNode `json:"nodes"`
+			}{
+				Nodes: []gqlStatusContextNode{{Conclusion: "FAILURE"}},
+			},
+		}),
+	)
+
+	got := classifyMyPullRequest(node)
+	if got != "blocked" {
+		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, "blocked")
+	}
+}

--- a/internal/ui/views/common/style.go
+++ b/internal/ui/views/common/style.go
@@ -2,10 +2,13 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/lipgloss/v2"
 )
+
+const spinnerFrameInterval = 100 * time.Millisecond
 
 var (
 	SubtleGray    = lipgloss.Color("#5b6078")
@@ -45,9 +48,26 @@ func NewRefreshSpinner() spinner.Model {
 }
 
 func NewPullSpinner() spinner.Model {
+	pullSpinner := spinner.Points
+	pullSpinner.FPS = spinnerFrameInterval
+
 	return spinner.New(
-		spinner.WithSpinner(spinner.Points),
+		spinner.WithSpinner(pullSpinner),
 		spinner.WithStyle(lipgloss.NewStyle().Foreground(Blue)),
+	)
+}
+
+func NewPullRequestSpinner() spinner.Model {
+	return NewRefreshSpinner()
+}
+
+func NewBlockedPullRequestSpinner() spinner.Model {
+	blockedSpinner := spinner.Pulse
+	blockedSpinner.FPS = spinnerFrameInterval
+
+	return spinner.New(
+		spinner.WithSpinner(blockedSpinner),
+		spinner.WithStyle(lipgloss.NewStyle().Foreground(SubtleRed).Bold(true)),
 	)
 }
 
@@ -130,6 +150,10 @@ var PullOutputError = lipgloss.NewStyle().
 	Height(1).
 	MaxHeight(1).
 	Inline(true)
+
+var AlertSpinnerStyle = lipgloss.NewStyle().
+	Foreground(Red).
+	Bold(true)
 
 var PullProgressStyle = lipgloss.NewStyle()
 

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -137,8 +137,10 @@ func listenForPruneProgress(state pruneWorkState) tea.Cmd {
 }
 
 func performPullRequestSync(repos []domain.Repository) tea.Cmd {
+	snapshot := append([]domain.Repository(nil), repos...)
+
 	return func() tea.Msg {
-		states := git.GetPullRequestStates(repos)
+		states := git.GetPullRequestStates(snapshot)
 		return PullRequestStatesUpdatedMsg{States: states}
 	}
 }

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -136,11 +136,11 @@ func listenForPruneProgress(state pruneWorkState) tea.Cmd {
 	}
 }
 
-func performPullRequestSync(repos []domain.Repository) tea.Cmd {
+func performPullRequestSync(repos []domain.Repository, trigger PullRequestSyncTrigger) tea.Cmd {
 	snapshot := append([]domain.Repository(nil), repos...)
 
 	return func() tea.Msg {
 		states := git.GetPullRequestStates(snapshot)
-		return PullRequestStatesUpdatedMsg{States: states}
+		return PullRequestStatesUpdatedMsg{States: states, Trigger: trigger}
 	}
 }

--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -20,8 +20,9 @@ const (
 )
 
 type InfoMessage struct {
-	Text string
-	Tone InfoTone
+	Text   string
+	Tone   InfoTone
+	Pinned bool
 }
 
 type TimedInfoMessage struct {
@@ -33,6 +34,9 @@ type InfoRuntime struct {
 	Phase                uint64
 	Now                  time.Time
 	RecentActivityByRepo map[string][]TimedInfoMessage
+	PullRequestSyncing   bool
+	PullRequestSpinner   string
+	BlockedSpinner       string
 }
 
 func collectStatusInfoMessages(repo domain.Repository) []InfoMessage {
@@ -50,8 +54,8 @@ func collectStatusInfoMessages(repo domain.Repository) []InfoMessage {
 		appendMessage(InfoMessage{Text: state.Message, Tone: InfoToneError})
 	}
 
-	if summary := buildMyPullRequestSummary(repo.PullRequests); summary != "" {
-		appendMessage(InfoMessage{Text: summary, Tone: InfoToneSubtle})
+	if summary, pinned := buildMyPullRequestSummary(repo.PullRequests); summary != "" {
+		appendMessage(InfoMessage{Text: summary, Tone: InfoToneSubtle, Pinned: pinned})
 	}
 
 	mergedCount := len(repo.Branches.Merged)
@@ -133,6 +137,16 @@ func collectRecentActivityInfoMessages(runtime InfoRuntime, repoPath string) []I
 	return messages
 }
 
+func filterPinnedInfoMessages(messages []InfoMessage) []InfoMessage {
+	pinned := make([]InfoMessage, 0, len(messages))
+	for _, message := range messages {
+		if message.Pinned {
+			pinned = append(pinned, message)
+		}
+	}
+	return pinned
+}
+
 func buildPullOutputInfoMessage(lastLine string, exitCode int) InfoMessage {
 	lowerLine := strings.ToLower(lastLine)
 
@@ -187,7 +201,6 @@ func renderInfoMessage(msg InfoMessage, infoWidth int) string {
 		return common.TextGrey.Render(text)
 	}
 }
-
 func normalizeInfoWidth(infoWidth int) int {
 	if infoWidth < 1 {
 		return 1

--- a/internal/ui/views/listing/layout.go
+++ b/internal/ui/views/listing/layout.go
@@ -21,6 +21,7 @@ const (
 	SelectorWidth  = 2
 	LocalWidth     = 15
 	RemoteWidth    = 11
+	PRAlertWidth   = 2
 	PRWidth        = 8
 	InfoWidth      = 42
 	MinInfoWidth   = 1
@@ -34,7 +35,7 @@ const (
 
 // totalFixedWidth returns the sum of all fixed-width columns plus inter-column gaps.
 func totalFixedWidthWithoutInfo() int {
-	return SelectorWidth + LocalWidth + RemoteWidth + PRWidth + (5 * InterColumnGap)
+	return SelectorWidth + LocalWidth + RemoteWidth + PRAlertWidth + PRWidth + (6 * InterColumnGap)
 }
 
 func calculateColumnLayout(repositories []domain.Repository, terminalWidth int) ColumnLayout {

--- a/internal/ui/views/listing/layout.go
+++ b/internal/ui/views/listing/layout.go
@@ -37,10 +37,6 @@ func totalFixedWidthWithoutInfo() int {
 	return SelectorWidth + LocalWidth + RemoteWidth + PRWidth + (5 * InterColumnGap)
 }
 
-func totalFixedWidth() int {
-	return totalFixedWidthWithoutInfo() + InfoWidth
-}
-
 func calculateColumnLayout(repositories []domain.Repository, terminalWidth int) ColumnLayout {
 	projectWidth, branchWidth := calculateColumnWidths(repositories, terminalWidth)
 	infoWidth := calculateInfoWidth(terminalWidth, projectWidth, branchWidth)

--- a/internal/ui/views/listing/layout_test.go
+++ b/internal/ui/views/listing/layout_test.go
@@ -34,19 +34,6 @@ func TestClamp(t *testing.T) {
 	}
 }
 
-func TestTotalFixedWidth(t *testing.T) {
-	t.Parallel()
-
-	// totalFixedWidth should return the sum of all fixed columns + gaps
-	expected := SelectorWidth + LocalWidth + RemoteWidth + PRWidth +
-		InfoWidth + (5 * InterColumnGap)
-
-	got := totalFixedWidth()
-	if got != expected {
-		t.Errorf("totalFixedWidth() = %d, want %d", got, expected)
-	}
-}
-
 func TestDistributeWidth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -15,6 +15,7 @@ import (
 
 type listKeyMap struct {
 	refresh      key.Binding
+	watch        key.Binding
 	pullAll      key.Binding
 	pruneAll     key.Binding
 	alert        key.Binding
@@ -26,6 +27,10 @@ func newListKeyMap() *listKeyMap {
 		refresh: key.NewBinding(
 			key.WithKeys("r"),
 			key.WithHelp("r", "refresh"),
+		),
+		watch: key.NewBinding(
+			key.WithKeys("w"),
+			key.WithHelp("w", "toggle watch mode"),
 		),
 		pullAll: key.NewBinding(
 			key.WithKeys("p"),
@@ -47,18 +52,26 @@ func newListKeyMap() *listKeyMap {
 }
 
 type Model struct {
-	Repositories  []domain.Repository
-	Cursor        int
-	Keys          *listKeyMap
-	layout        ColumnLayout
-	width, height int
-	ShowLegend    bool
-	InfoPhase     uint64
-	RotateEvery   time.Duration
-	ActivityTTL   time.Duration
-	RecentInfo    map[string][]TimedInfoMessage
-	StartupPRSync bool
-	notifier      *notifications.Notifier
+	Repositories   []domain.Repository
+	Cursor         int
+	Keys           *listKeyMap
+	layout         ColumnLayout
+	width, height  int
+	ShowLegend     bool
+	InfoPhase      uint64
+	RotateEvery    time.Duration
+	ActivityTTL    time.Duration
+	RecentInfo     map[string][]TimedInfoMessage
+	StartupPRSync  bool
+	PRSyncInFlight int
+	PRSyncSpinner  spinner.Model
+	BlockedSpinner spinner.Model
+	WatchEnabled   bool
+	WatchToken     uint64
+	WatchBackoff   int
+	WatchEvery     time.Duration
+	WatchMaxEvery  time.Duration
+	notifier       *notifications.Notifier
 }
 
 func New(repos []domain.Repository) *Model {
@@ -75,16 +88,24 @@ func NewWithNotifier(repos []domain.Repository, notifier *notifications.Notifier
 	}
 
 	return &Model{
-		Repositories:  repos,
-		Cursor:        0,
-		Keys:          newListKeyMap(),
-		layout:        calculateColumnLayout(repos, 0),
-		ShowLegend:    false,
-		RotateEvery:   10 * time.Second,
-		ActivityTTL:   10 * time.Second,
-		RecentInfo:    make(map[string][]TimedInfoMessage),
-		StartupPRSync: false,
-		notifier:      notifier,
+		Repositories:   repos,
+		Cursor:         0,
+		Keys:           newListKeyMap(),
+		layout:         calculateColumnLayout(repos, 0),
+		ShowLegend:     false,
+		RotateEvery:    10 * time.Second,
+		ActivityTTL:    10 * time.Second,
+		RecentInfo:     make(map[string][]TimedInfoMessage),
+		StartupPRSync:  false,
+		PRSyncInFlight: 0,
+		PRSyncSpinner:  common.NewPullRequestSpinner(),
+		BlockedSpinner: common.NewBlockedPullRequestSpinner(),
+		WatchEnabled:   false,
+		WatchToken:     0,
+		WatchBackoff:   0,
+		WatchEvery:     defaultWatchInterval,
+		WatchMaxEvery:  defaultWatchMaxInterval,
+		notifier:       notifier,
 	}
 }
 
@@ -98,9 +119,10 @@ func (m *Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
 	cmds = append(cmds, scheduleInfoRotateTick(m.RotateEvery))
 	if !m.StartupPRSync {
-		cmds = append(cmds, performPullRequestSync(m.Repositories))
+		cmds = append(cmds, m.startPullRequestSync(pullRequestSyncStartup)...)
 		m.StartupPRSync = true
 	}
+	cmds = append(cmds, m.BlockedSpinner.Tick)
 	for i := range m.Repositories {
 		repo := &m.Repositories[i]
 		repo.Activity = &domain.RefreshingActivity{
@@ -121,19 +143,10 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.Keys.refresh):
-			var cmds []tea.Cmd
-			cmds = append(cmds, performPullRequestSync(m.Repositories))
-			for i := range m.Repositories {
-				repo := &m.Repositories[i]
-				if !repo.IsBusy() {
-					repo.Activity = &domain.RefreshingActivity{
-						Spinner: common.NewRefreshSpinner(),
-					}
-					cmds = append(cmds, performRefresh(i, repo.Path))
-					cmds = append(cmds, repo.Activity.(*domain.RefreshingActivity).Spinner.Tick)
-				}
-			}
-			return m, tea.Batch(cmds...)
+			return m, m.startRefreshCycle(pullRequestSyncManual)
+
+		case key.Matches(msg, m.Keys.watch):
+			return m, m.toggleWatchMode()
 
 		case key.Matches(msg, m.Keys.pullAll):
 			var cmds []tea.Cmd
@@ -200,6 +213,17 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 
 	case PullRequestStatesUpdatedMsg:
 		m.applyPullRequestStates(msg.States)
+		m.completePullRequestSync()
+		if msg.Trigger == pullRequestSyncWatch && m.WatchEnabled {
+			m.updateWatchBackoff(hasPullRequestSyncError(msg.States))
+			return m, scheduleWatchTick(m.currentWatchInterval(), m.WatchToken)
+		}
+
+	case watchTickMsg:
+		if !m.WatchEnabled || msg.Token != m.WatchToken {
+			return m, nil
+		}
+		return m, m.startRefreshCycle(pullRequestSyncWatch)
 
 	case pullWorkState:
 		return m, listenForPullProgress(msg)
@@ -270,6 +294,16 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 
 	case spinner.TickMsg:
 		var cmds []tea.Cmd
+		if m.isPullRequestSyncInFlight() {
+			var cmd tea.Cmd
+			m.PRSyncSpinner, cmd = m.PRSyncSpinner.Update(msg)
+			cmds = append(cmds, cmd)
+		}
+		var blockedCmd tea.Cmd
+		m.BlockedSpinner, blockedCmd = m.BlockedSpinner.Update(msg)
+		if blockedCmd != nil {
+			cmds = append(cmds, blockedCmd)
+		}
 		for i := range m.Repositories {
 			switch activity := m.Repositories[i].Activity.(type) {
 			case *domain.RefreshingActivity:
@@ -325,11 +359,14 @@ func (m *Model) View() string {
 		Phase:                m.InfoPhase,
 		Now:                  time.Now(),
 		RecentActivityByRepo: m.RecentInfo,
+		PullRequestSyncing:   m.isPullRequestSyncInFlight(),
+		PullRequestSpinner:   m.pullRequestSpinnerView(),
+		BlockedSpinner:       m.BlockedSpinner.View(),
 	}
 	s.WriteString(GenerateTable(m.Repositories, m.Cursor, m.layout, runtime))
 	s.WriteString("\n\n")
 
-	s.WriteString(buildFooter())
+	s.WriteString(m.buildFooter())
 
 	legend := RenderLegend(m.ShowLegend)
 	s.WriteString("\n\n")
@@ -338,10 +375,16 @@ func (m *Model) View() string {
 	return s.String()
 }
 
-func buildFooter() string {
+func (m *Model) buildFooter() string {
+	watchStatus := "w watch off"
+	if m.WatchEnabled {
+		watchStatus = "w watch on (" + m.currentWatchInterval().String() + ")"
+	}
+
 	hotkeys := []string{
 		"↑/↓ navigate",
 		"r refresh",
+		watchStatus,
 		"p pull all updates",
 		"b prune merged branches",
 		"a mock alert",

--- a/internal/ui/views/listing/listing_test.go
+++ b/internal/ui/views/listing/listing_test.go
@@ -7,49 +7,7 @@ import (
 
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/common"
-
-	tea "charm.land/bubbletea/v2"
 )
-
-// Minimal smoke test to ensure v2 compatibility
-func TestNew(t *testing.T) {
-	m := New(nil)
-	if m == nil {
-		t.Fatal("New() returned nil")
-	}
-	if m.Cursor != 0 {
-		t.Errorf("Cursor = %d, want 0", m.Cursor)
-	}
-}
-
-// Test that Update accepts tea.Msg and returns (*Model, tea.Cmd)
-func TestUpdate_WindowSize(t *testing.T) {
-	m := New(nil)
-	msg := tea.WindowSizeMsg{Width: 100, Height: 40}
-
-	newM, cmd := m.Update(msg)
-	if newM == nil {
-		t.Error("Update returned nil model")
-	}
-	if newM.width != 100 {
-		t.Errorf("width = %d, want 100", newM.width)
-	}
-	if cmd != nil {
-		t.Error("expected nil cmd from WindowSizeMsg")
-	}
-}
-
-// Test View returns content
-func TestView_Empty(t *testing.T) {
-	m := New(nil)
-	m.width = 120
-	m.height = 40
-
-	view := m.View()
-	if view == "" {
-		t.Error("View() returned empty string")
-	}
-}
 
 func TestUpdate_InfoRotateTick_IncrementsPhase(t *testing.T) {
 	m := New(nil)

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -13,8 +13,18 @@ type RepoUpdatedMsg struct {
 	Index int
 }
 
+type PullRequestSyncTrigger int
+
+const (
+	pullRequestSyncUnknown PullRequestSyncTrigger = iota
+	pullRequestSyncStartup
+	pullRequestSyncManual
+	pullRequestSyncWatch
+)
+
 type PullRequestStatesUpdatedMsg struct {
-	States map[string]domain.PullRequestState
+	States  map[string]domain.PullRequestState
+	Trigger PullRequestSyncTrigger
 }
 
 type pullLineMsg struct {

--- a/internal/ui/views/listing/pull_request_sync.go
+++ b/internal/ui/views/listing/pull_request_sync.go
@@ -1,0 +1,33 @@
+package listing
+
+import tea "charm.land/bubbletea/v2"
+
+func (m *Model) startPullRequestSync(trigger PullRequestSyncTrigger) []tea.Cmd {
+	m.PRSyncInFlight++
+
+	return []tea.Cmd{
+		performPullRequestSync(m.Repositories, trigger),
+		m.PRSyncSpinner.Tick,
+	}
+}
+
+func (m *Model) completePullRequestSync() {
+	if m.PRSyncInFlight <= 0 {
+		m.PRSyncInFlight = 0
+		return
+	}
+
+	m.PRSyncInFlight--
+}
+
+func (m *Model) isPullRequestSyncInFlight() bool {
+	return m.PRSyncInFlight > 0
+}
+
+func (m *Model) pullRequestSpinnerView() string {
+	if !m.isPullRequestSyncInFlight() {
+		return ""
+	}
+
+	return m.PRSyncSpinner.View()
+}

--- a/internal/ui/views/listing/pull_request_sync_test.go
+++ b/internal/ui/views/listing/pull_request_sync_test.go
@@ -1,0 +1,102 @@
+package listing
+
+import (
+	"testing"
+
+	"fresh/internal/domain"
+
+	"charm.land/bubbles/v2/spinner"
+)
+
+func TestStartPullRequestSyncMarksInFlightAndReturnsCommands(t *testing.T) {
+	m := New(nil)
+	cmds := m.startPullRequestSync(pullRequestSyncManual)
+
+	if m.PRSyncInFlight != 1 {
+		t.Fatalf("PRSyncInFlight = %d, want 1", m.PRSyncInFlight)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("len(cmds) = %d, want 2", len(cmds))
+	}
+	if cmds[0] == nil || cmds[1] == nil {
+		t.Fatal("expected non-nil sync commands")
+	}
+}
+
+func TestCompletePullRequestSyncDoesNotGoNegative(t *testing.T) {
+	m := New(nil)
+	m.completePullRequestSync()
+
+	if m.PRSyncInFlight != 0 {
+		t.Fatalf("PRSyncInFlight = %d, want 0", m.PRSyncInFlight)
+	}
+
+	m.PRSyncInFlight = 1
+	m.completePullRequestSync()
+	if m.PRSyncInFlight != 0 {
+		t.Fatalf("PRSyncInFlight = %d, want 0", m.PRSyncInFlight)
+	}
+}
+
+func TestUpdateSpinnerTickAdvancesPRSpinnerWhenSyncing(t *testing.T) {
+	m := New(nil)
+	_ = m.startPullRequestSync(pullRequestSyncManual)
+
+	newM, cmd := m.Update(spinner.TickMsg{})
+	if newM == nil {
+		t.Fatal("expected model")
+	}
+	if cmd == nil {
+		t.Fatal("expected follow-up spinner tick command")
+	}
+}
+
+func TestUpdatePullRequestStatesCompletesInFlightSync(t *testing.T) {
+	m := New(nil)
+	_ = m.startPullRequestSync(pullRequestSyncManual)
+
+	newM, _ := m.Update(PullRequestStatesUpdatedMsg{Trigger: pullRequestSyncManual})
+	if newM == nil {
+		t.Fatal("expected model")
+	}
+	if m.PRSyncInFlight != 0 {
+		t.Fatalf("PRSyncInFlight = %d, want 0", m.PRSyncInFlight)
+	}
+}
+
+func TestPullRequestSpinnerViewEmptyWhenNotSyncing(t *testing.T) {
+	m := New(nil)
+	if got := m.pullRequestSpinnerView(); got != "" {
+		t.Fatalf("pullRequestSpinnerView() = %q, want empty", got)
+	}
+}
+
+func TestStartRefreshCycleStartsPRSyncAndRepoRefresh(t *testing.T) {
+	m := New(sampleWatchRepos())
+
+	cmd := m.startRefreshCycle(pullRequestSyncManual)
+	if cmd == nil {
+		t.Fatal("expected batch command")
+	}
+	if m.PRSyncInFlight != 1 {
+		t.Fatalf("PRSyncInFlight = %d, want 1", m.PRSyncInFlight)
+	}
+
+	if _, ok := m.Repositories[0].Activity.(*domain.RefreshingActivity); !ok {
+		t.Fatalf("repo activity = %T, want *domain.RefreshingActivity", m.Repositories[0].Activity)
+	}
+}
+
+func sampleWatchRepos() []domain.Repository {
+	return []domain.Repository{
+		{
+			Name:        "demo",
+			Path:        "/tmp/demo",
+			RemoteURL:   "https://github.com/org/demo.git",
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+			Activity:    &domain.IdleActivity{},
+		},
+	}
+}

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -12,7 +12,7 @@ import (
 )
 
 func GenerateTable(repositories []domain.Repository, cursor int, layout ColumnLayout, runtime InfoRuntime) string {
-	headers := []string{"", "󰉋 Repo", " Branch", " Local", "󰓦 Remote", common.IconPullRequests + " PR", ""}
+	headers := []string{"", "󰉋 Repo", " Branch", " Local", "󰓦 Remote", common.IconPullRequests + " PR", "", ""}
 
 	rows := make([][]string, len(repositories))
 	for i, repo := range repositories {
@@ -41,7 +41,8 @@ func repositoryToRow(repo domain.Repository, isSelected bool, layout ColumnLayou
 	branchName := buildBranchName(repo.Branches.Current, layout.BranchWidth)
 	localCol := buildLocalStatus(repo.LocalState)
 	remoteCol := buildRemoteStatus(repo)
-	prCol := buildPullRequestStatus(repo.PullRequests)
+	prCol := buildPullRequestStatus(repo.PullRequests, runtime)
+	prAlertCol := buildPullRequestAlert(repo.PullRequests, runtime)
 	info := buildInfo(repo, layout.InfoWidth, runtime)
 
 	return []string{
@@ -51,8 +52,30 @@ func repositoryToRow(repo domain.Repository, isSelected bool, layout ColumnLayou
 		localCol,
 		remoteCol,
 		prCol,
+		prAlertCol,
 		info,
 	}
+}
+
+func buildPullRequestAlert(state domain.PullRequestState, runtime InfoRuntime) string {
+	style := lipgloss.NewStyle().
+		Width(PRAlertWidth).
+		MaxWidth(PRAlertWidth).
+		Height(1).
+		MaxHeight(1).
+		Align(lipgloss.Left)
+
+	s, ok := state.(domain.PullRequestCount)
+	if !ok || s.MyBlocked <= 0 {
+		return style.Render("")
+	}
+
+	frame := runtime.BlockedSpinner
+	if frame == "" {
+		return style.Foreground(common.SubtleRed).Render(common.IconWarning)
+	}
+
+	return style.Foreground(common.SubtleRed).Render(frame)
 }
 
 func buildSelector(isSelected bool) string {
@@ -64,18 +87,29 @@ func buildSelector(isSelected bool) string {
 }
 
 func buildProjectName(name string, isSelected bool, width int) string {
+	if width < 1 {
+		width = 1
+	}
+
+	displayName := name
+	if lipgloss.Width(name) > width {
+		displayName = common.TruncateWithEllipsis(name, width)
+	}
+
 	style := lipgloss.NewStyle().
 		Foreground(common.TextPrimary).
 		Align(lipgloss.Left).
 		Width(width).
 		MaxWidth(width).
+		Height(1).
+		MaxHeight(1).
 		AlignHorizontal(lipgloss.Left)
 
 	if isSelected {
 		style = style.Bold(true)
 	}
 
-	return style.Render(name)
+	return style.Render(displayName)
 }
 
 func buildBranchName(branch domain.Branch, width int) string {
@@ -170,18 +204,24 @@ func buildRemoteStatus(repo domain.Repository) string {
 	}
 }
 
-func buildPullRequestStatus(state domain.PullRequestState) string {
+func buildPullRequestStatus(state domain.PullRequestState, runtime InfoRuntime) string {
 	baseStyle := common.PullRequestStatusBaseStyle.
 		Width(PRWidth).
 		MaxWidth(PRWidth)
 
+	if runtime.PullRequestSyncing {
+		return baseStyle.Render(runtime.PullRequestSpinner)
+	}
+
 	switch s := state.(type) {
 	case domain.PullRequestCount:
 		if s.Open <= 0 {
-			return baseStyle.Foreground(common.SubtleGray).Render("0")
+			return baseStyle.Render("")
 		}
 		if s.MyOpen > 0 {
-			return baseStyle.Foreground(common.Blue).Render(fmt.Sprintf("%d(*)", s.Open))
+			count := lipgloss.NewStyle().Foreground(common.Blue).Render(fmt.Sprintf("%d", s.Open))
+			mine := lipgloss.NewStyle().Foreground(common.TextPrimary).Render("(*)")
+			return baseStyle.Render(count + mine)
 		}
 		return baseStyle.Foreground(common.Blue).Render(fmt.Sprintf("%d", s.Open))
 	case domain.PullRequestError:
@@ -213,6 +253,16 @@ func buildInfo(repo domain.Repository, infoWidth int, runtime InfoRuntime) strin
 		return infoStyle.Render("")
 	}
 
+	pinned := filterPinnedInfoMessages(messages)
+	if len(pinned) > 0 {
+		idx := 0
+		if len(pinned) > 1 {
+			idx = int(runtime.Phase % uint64(len(pinned)))
+		}
+
+		return infoStyle.Render(renderInfoMessage(pinned[idx], infoWidth))
+	}
+
 	idx := 0
 	if len(messages) > 1 {
 		idx = int(runtime.Phase % uint64(len(messages)))
@@ -221,18 +271,20 @@ func buildInfo(repo domain.Repository, infoWidth int, runtime InfoRuntime) strin
 	return infoStyle.Render(renderInfoMessage(messages[idx], infoWidth))
 }
 
-func buildMyPullRequestSummary(state domain.PullRequestState) string {
+func buildMyPullRequestSummary(state domain.PullRequestState) (string, bool) {
 	s, ok := state.(domain.PullRequestCount)
 	if !ok {
-		return ""
+		return "", false
 	}
 
 	parts := make([]string, 0, 4)
+	hasPinned := false
 	if s.MyReady > 0 {
 		parts = append(parts, fmt.Sprintf("%d ready", s.MyReady))
 	}
 	if s.MyBlocked > 0 {
 		parts = append(parts, fmt.Sprintf("%d blocked", s.MyBlocked))
+		hasPinned = true
 	}
 	if s.MyChecks > 0 {
 		parts = append(parts, fmt.Sprintf("%d checks", s.MyChecks))
@@ -242,10 +294,10 @@ func buildMyPullRequestSummary(state domain.PullRequestState) string {
 	}
 
 	if len(parts) == 0 {
-		return ""
+		return "", false
 	}
 
-	return "My PRs: " + strings.Join(parts, ", ")
+	return "My PRs: " + strings.Join(parts, ", "), hasPinned
 }
 
 func stylePullOutput(lastLine string, exitCode int, infoWidth int) string {

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -7,6 +7,8 @@ import (
 
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/common"
+
+	"charm.land/lipgloss/v2"
 )
 
 // ============================================================================
@@ -86,6 +88,18 @@ func TestBuildProjectName(t *testing.T) {
 					tt.project, tt.isSelected, tt.width, got, tt.project)
 			}
 		})
+	}
+}
+
+func TestBuildProjectName_TruncatesWithEllipsis(t *testing.T) {
+	t.Parallel()
+
+	got := buildProjectName("this-is-a-very-long-repository-name", false, 12)
+	if !strings.Contains(got, "...") {
+		t.Fatalf("buildProjectName() = %q, want ellipsis", got)
+	}
+	if strings.Contains(got, "this-is-a-very-long-repository-name") {
+		t.Fatalf("buildProjectName() = %q, did not expect full untruncated name", got)
 	}
 }
 
@@ -305,6 +319,7 @@ func TestBuildPullRequestStatus(t *testing.T) {
 		name     string
 		state    domain.PullRequestState
 		contains []string
+		isEmpty  bool
 	}{
 		{
 			name:     "open pull requests show icon and count",
@@ -312,14 +327,14 @@ func TestBuildPullRequestStatus(t *testing.T) {
 			contains: []string{"3"},
 		},
 		{
-			name:     "zero pull requests shows icon and zero",
-			state:    domain.PullRequestCount{Open: 0, MyOpen: 0},
-			contains: []string{"0"},
+			name:    "zero pull requests shows empty",
+			state:   domain.PullRequestCount{Open: 0, MyOpen: 0},
+			isEmpty: true,
 		},
 		{
 			name:     "my open pull request still shows icon and count",
 			state:    domain.PullRequestCount{Open: 2, MyOpen: 1},
-			contains: []string{"2(*)"},
+			contains: []string{"2", "(*)"},
 		},
 		{
 			name:     "unavailable pull requests show dash",
@@ -336,11 +351,90 @@ func TestBuildPullRequestStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := buildPullRequestStatus(tt.state)
+			got := buildPullRequestStatus(tt.state, InfoRuntime{})
+			if tt.isEmpty {
+				trimmed := strings.TrimSpace(got)
+				if trimmed != "" {
+					t.Errorf("buildPullRequestStatus(%q) = %q, want empty", tt.name, got)
+				}
+				return
+			}
 			for _, want := range tt.contains {
 				if !strings.Contains(got, want) {
 					t.Errorf("buildPullRequestStatus(%q) = %q, want it to contain %q", tt.name, got, want)
 				}
+			}
+		})
+	}
+}
+
+func TestBuildPullRequestStatus_MyOpenUsesWhiteMarker(t *testing.T) {
+	t.Parallel()
+
+	got := buildPullRequestStatus(domain.PullRequestCount{Open: 2, MyOpen: 1}, InfoRuntime{})
+	wantMarker := lipgloss.NewStyle().Foreground(common.TextPrimary).Render("(*)")
+
+	if !strings.Contains(got, wantMarker) {
+		t.Fatalf("buildPullRequestStatus() = %q, expected white marker %q", got, wantMarker)
+	}
+}
+
+func TestBuildPullRequestStatus_SyncingShowsSpinnerOnly(t *testing.T) {
+	t.Parallel()
+
+	runtime := InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋"}
+	got := buildPullRequestStatus(domain.PullRequestCount{Open: 9, MyOpen: 1}, runtime)
+
+	if !strings.Contains(got, "⠋") {
+		t.Fatalf("buildPullRequestStatus() = %q, want spinner", got)
+	}
+	if strings.Contains(got, "9") || strings.Contains(got, "(*)") {
+		t.Fatalf("buildPullRequestStatus() = %q, want spinner-only content", got)
+	}
+}
+
+func TestBuildPullRequestAlert(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		state    domain.PullRequestState
+		runtime  InfoRuntime
+		contains string
+		isEmpty  bool
+	}{
+		{
+			name:    "syncing keeps alert empty",
+			state:   domain.PullRequestCount{Open: 9, MyOpen: 1},
+			runtime: InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋"},
+			isEmpty: true,
+		},
+		{
+			name:     "blocked my prs show alert spinner",
+			state:    domain.PullRequestCount{MyBlocked: 2},
+			runtime:  InfoRuntime{BlockedSpinner: "█"},
+			contains: "█",
+		},
+		{
+			name:    "no blocked prs shows empty",
+			state:   domain.PullRequestCount{MyBlocked: 0},
+			runtime: InfoRuntime{},
+			isEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildPullRequestAlert(tt.state, tt.runtime)
+			if tt.isEmpty {
+				if strings.TrimSpace(got) != "" {
+					t.Fatalf("buildPullRequestAlert(%q) = %q, want empty", tt.name, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.contains) {
+				t.Fatalf("buildPullRequestAlert(%q) = %q, want %q", tt.name, got, tt.contains)
 			}
 		})
 	}
@@ -404,7 +498,7 @@ func TestBuildMyPullRequestSummary(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := buildMyPullRequestSummary(tt.state)
+			got, _ := buildMyPullRequestSummary(tt.state)
 			if tt.isEmpty {
 				if got != "" {
 					t.Errorf("buildMyPullRequestSummary(%q) = %q, want empty", tt.name, got)
@@ -417,6 +511,22 @@ func TestBuildMyPullRequestSummary(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildMyPullRequestSummary_BlockedIsPinned(t *testing.T) {
+	t.Parallel()
+
+	state := domain.PullRequestCount{MyBlocked: 2}
+
+	got, pinned := buildMyPullRequestSummary(state)
+
+	if !pinned {
+		t.Fatalf("buildMyPullRequestSummary() pinned = false, want true")
+	}
+
+	if !strings.Contains(got, "2 blocked") {
+		t.Fatalf("summary = %q, want blocked count", got)
 	}
 }
 
@@ -703,8 +813,8 @@ func TestRepositoryToRow(t *testing.T) {
 
 	row := repositoryToRow(repo, true, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 
-	if len(row) != 7 {
-		t.Fatalf("repositoryToRow returned %d columns, want 7", len(row))
+	if len(row) != 8 {
+		t.Fatalf("repositoryToRow returned %d columns, want 8", len(row))
 	}
 
 	// Selector should have the icon since isSelected=true
@@ -732,8 +842,12 @@ func TestRepositoryToRow(t *testing.T) {
 		t.Errorf("row[4] (remote) = %q, want it to contain %q", row[4], common.IconSynced)
 	}
 
-	if !strings.Contains(row[5], "2(*)") {
-		t.Errorf("row[5] (prs) = %q, want it to contain %q", row[5], "2(*)")
+	if !strings.Contains(row[5], "2") || !strings.Contains(row[5], "(*)") {
+		t.Errorf("row[5] (prs) = %q, want it to contain count and marker", row[5])
+	}
+
+	if strings.TrimSpace(row[6]) != "" {
+		t.Errorf("row[6] (pr alert) = %q, want empty when no blocked PRs", row[6])
 	}
 }
 

--- a/internal/ui/views/listing/watch.go
+++ b/internal/ui/views/listing/watch.go
@@ -1,0 +1,113 @@
+package listing
+
+import (
+	"time"
+
+	"fresh/internal/domain"
+	"fresh/internal/ui/views/common"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	defaultWatchInterval    = time.Minute
+	defaultWatchMaxInterval = 8 * time.Minute
+	maxWatchBackoff         = 8
+)
+
+type watchTickMsg struct {
+	Token uint64
+}
+
+func scheduleWatchTick(interval time.Duration, token uint64) tea.Cmd {
+	if interval <= 0 {
+		interval = defaultWatchInterval
+	}
+
+	return tea.Tick(interval, func(time.Time) tea.Msg {
+		return watchTickMsg{Token: token}
+	})
+}
+
+func (m *Model) toggleWatchMode() tea.Cmd {
+	if m.WatchEnabled {
+		m.WatchEnabled = false
+		m.WatchBackoff = 0
+		m.WatchToken++
+		return nil
+	}
+
+	m.WatchEnabled = true
+	m.WatchBackoff = 0
+	m.WatchToken++
+
+	return scheduleWatchTick(m.currentWatchInterval(), m.WatchToken)
+}
+
+func (m *Model) startRefreshCycle(trigger PullRequestSyncTrigger) tea.Cmd {
+	var cmds []tea.Cmd
+	cmds = append(cmds, m.startPullRequestSync(trigger)...)
+	for i := range m.Repositories {
+		repo := &m.Repositories[i]
+		if repo.IsBusy() {
+			continue
+		}
+		repo.Activity = &domain.RefreshingActivity{Spinner: common.NewRefreshSpinner()}
+		cmds = append(cmds, performRefresh(i, repo.Path))
+		cmds = append(cmds, repo.Activity.(*domain.RefreshingActivity).Spinner.Tick)
+	}
+
+	return tea.Batch(cmds...)
+}
+
+func (m *Model) currentWatchInterval() time.Duration {
+	base, max := m.watchIntervals()
+	interval := base
+
+	for i := 0; i < m.WatchBackoff; i++ {
+		if interval >= max {
+			return max
+		}
+		next := interval * 2
+		if next > max {
+			return max
+		}
+		interval = next
+	}
+
+	return interval
+}
+
+func (m *Model) watchIntervals() (time.Duration, time.Duration) {
+	base := m.WatchEvery
+	if base <= 0 {
+		base = defaultWatchInterval
+	}
+
+	max := m.WatchMaxEvery
+	if max < base {
+		max = base
+	}
+
+	return base, max
+}
+
+func (m *Model) updateWatchBackoff(hasError bool) {
+	if !hasError {
+		m.WatchBackoff = 0
+		return
+	}
+
+	if m.WatchBackoff < maxWatchBackoff {
+		m.WatchBackoff++
+	}
+}
+
+func hasPullRequestSyncError(states map[string]domain.PullRequestState) bool {
+	for _, state := range states {
+		if _, ok := state.(domain.PullRequestError); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ui/views/listing/watch_test.go
+++ b/internal/ui/views/listing/watch_test.go
@@ -1,0 +1,208 @@
+package listing
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"fresh/internal/domain"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestToggleWatchModeTurnsOnAndSchedulesTick(t *testing.T) {
+	m := New(nil)
+	if m.WatchEnabled {
+		t.Fatal("watch mode should start disabled")
+	}
+
+	cmd := m.toggleWatchMode()
+	if !m.WatchEnabled {
+		t.Fatal("watch mode should be enabled")
+	}
+	if cmd == nil {
+		t.Fatal("expected watch tick command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(watchTickMsg); !ok {
+		t.Fatalf("command message = %T, want watchTickMsg", msg)
+	}
+}
+
+func TestToggleWatchModeTurnsOffAndCancelsPendingTicks(t *testing.T) {
+	m := New(nil)
+	_ = m.toggleWatchMode()
+	tokenOn := m.WatchToken
+
+	cmd := m.toggleWatchMode()
+	if m.WatchEnabled {
+		t.Fatal("watch mode should be disabled")
+	}
+	if cmd != nil {
+		t.Fatal("disabling watch should not schedule new command")
+	}
+	if m.WatchToken <= tokenOn {
+		t.Fatal("watch token should advance to invalidate pending ticks")
+	}
+}
+
+func TestCurrentWatchIntervalBackoffDoublesToMax(t *testing.T) {
+	m := New(nil)
+	m.WatchEvery = time.Minute
+	m.WatchMaxEvery = 8 * time.Minute
+
+	intervals := []time.Duration{
+		time.Minute,
+		2 * time.Minute,
+		4 * time.Minute,
+		8 * time.Minute,
+		8 * time.Minute,
+	}
+
+	for i, want := range intervals {
+		m.WatchBackoff = i
+		if got := m.currentWatchInterval(); got != want {
+			t.Fatalf("backoff %d interval = %s, want %s", i, got, want)
+		}
+	}
+}
+
+func TestHasPullRequestSyncError(t *testing.T) {
+	noError := map[string]domain.PullRequestState{
+		"/repo/a": domain.PullRequestCount{Open: 1},
+		"/repo/b": domain.PullRequestUnavailable{},
+	}
+	if hasPullRequestSyncError(noError) {
+		t.Fatal("expected false when no PullRequestError present")
+	}
+
+	withError := map[string]domain.PullRequestState{
+		"/repo/a": domain.PullRequestCount{Open: 1},
+		"/repo/b": domain.PullRequestError{Message: "rate limited"},
+	}
+	if !hasPullRequestSyncError(withError) {
+		t.Fatal("expected true when PullRequestError is present")
+	}
+}
+
+func TestUpdateWatchTickIgnoresStaleToken(t *testing.T) {
+	m := New(nil)
+	_ = m.toggleWatchMode()
+	currentToken := m.WatchToken
+
+	newM, cmd := m.Update(watchTickMsg{Token: currentToken + 1})
+	if newM == nil {
+		t.Fatal("expected model")
+	}
+	if cmd != nil {
+		t.Fatal("stale tick should not schedule work")
+	}
+}
+
+func TestUpdateWatchTickStartsWatchRefreshCycle(t *testing.T) {
+	m := New([]domain.Repository{
+		{
+			Name:        "demo",
+			Path:        "/tmp/demo",
+			RemoteURL:   "https://github.com/org/demo.git",
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+			RemoteState: domain.Synced{},
+			LocalState:  domain.CleanLocalState{},
+			Activity:    &domain.IdleActivity{},
+		},
+	})
+	_ = m.toggleWatchMode()
+
+	newM, cmd := m.Update(watchTickMsg{Token: m.WatchToken})
+	if newM == nil {
+		t.Fatal("expected model")
+	}
+	if cmd == nil {
+		t.Fatal("expected watch refresh command batch")
+	}
+
+	if _, ok := newM.Repositories[0].Activity.(*domain.RefreshingActivity); !ok {
+		t.Fatalf("repo activity = %T, want *domain.RefreshingActivity", newM.Repositories[0].Activity)
+	}
+
+	type batchCommand interface {
+		Cmds() []tea.Cmd
+	}
+	if _, ok := any(cmd).(batchCommand); !ok {
+		// Bubble Tea batch cmd type is unexported; tolerate inability to assert internals.
+		if msg := cmd(); msg == nil {
+			t.Fatal("expected non-nil message from watch refresh command")
+		}
+	}
+}
+
+func TestBuildFooterShowsWatchStatus(t *testing.T) {
+	m := New(nil)
+	footer := m.buildFooter()
+
+	if !strings.Contains(footer, "w watch off") {
+		t.Fatalf("footer = %q, want watch off label", footer)
+	}
+
+	_ = m.toggleWatchMode()
+	footer = m.buildFooter()
+	if !strings.Contains(footer, "w watch on") {
+		t.Fatalf("footer = %q, want watch on label", footer)
+	}
+}
+
+func TestPullRequestWatchErrorBackoffSchedulesLongerInterval(t *testing.T) {
+	m := New(nil)
+	_ = m.toggleWatchMode()
+
+	if got := m.currentWatchInterval(); got != time.Minute {
+		t.Fatalf("currentWatchInterval() = %s, want %s", got, time.Minute)
+	}
+
+	newM, cmd := m.Update(PullRequestStatesUpdatedMsg{
+		States: map[string]domain.PullRequestState{
+			"/repo/a": domain.PullRequestError{Message: "gh: rate limit"},
+		},
+		Trigger: pullRequestSyncWatch,
+	})
+
+	if newM == nil {
+		t.Fatal("expected updated model")
+	}
+	if cmd == nil {
+		t.Fatal("expected watch reschedule command")
+	}
+	if m.WatchBackoff != 1 {
+		t.Fatalf("WatchBackoff = %d, want 1", m.WatchBackoff)
+	}
+	if got := m.currentWatchInterval(); got != 2*time.Minute {
+		t.Fatalf("currentWatchInterval() = %s, want %s", got, 2*time.Minute)
+	}
+}
+
+func TestPullRequestWatchSuccessResetsBackoff(t *testing.T) {
+	m := New(nil)
+	_ = m.toggleWatchMode()
+	m.WatchBackoff = 3
+
+	newM, cmd := m.Update(PullRequestStatesUpdatedMsg{
+		States: map[string]domain.PullRequestState{
+			"/repo/a": domain.PullRequestCount{Open: 1},
+		},
+		Trigger: pullRequestSyncWatch,
+	})
+
+	if newM == nil {
+		t.Fatal("expected updated model")
+	}
+	if cmd == nil {
+		t.Fatal("expected watch reschedule command")
+	}
+	if m.WatchBackoff != 0 {
+		t.Fatalf("WatchBackoff = %d, want 0", m.WatchBackoff)
+	}
+	if got := m.currentWatchInterval(); got != time.Minute {
+		t.Fatalf("currentWatchInterval() = %s, want %s", got, time.Minute)
+	}
+}


### PR DESCRIPTION
## Summary
- Snapshot repository slices before scheduling pull-request sync commands to avoid sharing mutable backing arrays across async command execution.
- Add decision-matrix coverage for `classifyMyPullRequest` including draft, blocked, pending checks, approved, and review-required paths.
- Remove dead `totalFixedWidth` helper and the redundant `TestTotalFixedWidth`, plus drop minimal smoke tests in listing that overlapped with stronger table/listing behavior coverage.

## Validation
- go test ./...