### PR TITLE
Remove unused pullRequestSyncUnknown trigger

### DIFF
--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -16,8 +16,7 @@ type RepoUpdatedMsg struct {
 type PullRequestSyncTrigger int
 
 const (
-	pullRequestSyncUnknown PullRequestSyncTrigger = iota
-	pullRequestSyncStartup
+	pullRequestSyncStartup PullRequestSyncTrigger = iota + 1
 	pullRequestSyncManual
 	pullRequestSyncWatch
 )


### PR DESCRIPTION
## Summary
- remove unused `pullRequestSyncUnknown` enum value from listing messages
- keep remaining trigger numeric values stable by starting at `iota + 1`

## Testing
- not run (`go` command is not available in this environment)