### PR TITLE
DRY listing test fixtures and activity-info formatting

### DIFF
--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -89,22 +89,24 @@ func collectActiveActivityInfoMessage(repo domain.Repository, infoWidth int) (In
 
 	switch activity := repo.Activity.(type) {
 	case *domain.PullingActivity:
-		if activity.Complete {
-			return InfoMessage{}, false
-		}
-		lastLine := activity.GetLastLine()
-		truncated := common.TruncateWithEllipsis(lastLine, max(1, infoWidth-3))
-		return InfoMessage{Text: common.FormatPullProgress(activity.Spinner.View(), truncated, max(1, infoWidth-2)), Tone: InfoTonePrimary}, true
+		return formatActiveProgressInfoMessage(activity.Complete, activity.Spinner.View(), activity.GetLastLine(), infoWidth)
 	case *domain.PruningActivity:
-		if activity.Complete {
-			return InfoMessage{}, false
-		}
-		lastLine := activity.GetLastLine()
-		truncated := common.TruncateWithEllipsis(lastLine, max(1, infoWidth-3))
-		return InfoMessage{Text: common.FormatPullProgress(activity.Spinner.View(), truncated, max(1, infoWidth-2)), Tone: InfoTonePrimary}, true
+		return formatActiveProgressInfoMessage(activity.Complete, activity.Spinner.View(), activity.GetLastLine(), infoWidth)
 	default:
 		return InfoMessage{}, false
 	}
+}
+
+func formatActiveProgressInfoMessage(complete bool, spinnerView, lastLine string, infoWidth int) (InfoMessage, bool) {
+	if complete {
+		return InfoMessage{}, false
+	}
+
+	truncated := common.TruncateWithEllipsis(lastLine, max(1, infoWidth-3))
+	return InfoMessage{
+		Text: common.FormatPullProgress(spinnerView, truncated, max(1, infoWidth-2)),
+		Tone: InfoTonePrimary,
+	}, true
 }
 
 func collectRecentActivityInfoMessages(runtime InfoRuntime, repoPath string) []InfoMessage {

--- a/internal/ui/views/listing/listing_test.go
+++ b/internal/ui/views/listing/listing_test.go
@@ -88,16 +88,11 @@ func TestStoreAndPruneRecentActivityInfo(t *testing.T) {
 func TestBuildInfo_CompletedActivityRequiresRecentInfo(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name: "demo",
-		Path: "/tmp/demo",
-		Activity: &domain.PullingActivity{
-			LineBuffer: domain.LineBuffer{Lines: []string{"Already up to date."}},
-			Complete:   true,
-			ExitCode:   0,
-		},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+	repo := makeTestRepository("demo")
+	repo.Activity = &domain.PullingActivity{
+		LineBuffer: domain.LineBuffer{Lines: []string{"Already up to date."}},
+		Complete:   true,
+		ExitCode:   0,
 	}
 
 	withoutRecent := buildInfo(repo, InfoWidth, InfoRuntime{})

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -423,13 +423,7 @@ func TestBuildMyPullRequestSummary(t *testing.T) {
 func TestBuildInfo_UsesRecentActivityOverStatus(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name:        "demo",
-		Path:        "/tmp/demo",
-		Activity:    domain.IdleActivity{},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-	}
+	repo := makeTestRepository("demo")
 
 	runtime := InfoRuntime{
 		Phase:                0,

--- a/internal/ui/views/listing/test_helpers_test.go
+++ b/internal/ui/views/listing/test_helpers_test.go
@@ -1,0 +1,14 @@
+package listing
+
+import "fresh/internal/domain"
+
+func makeTestRepository(name string) domain.Repository {
+	return domain.Repository{
+		Name:        name,
+		Path:        "/tmp/" + name,
+		Activity:    domain.IdleActivity{},
+		LocalState:  domain.CleanLocalState{},
+		RemoteState: domain.Synced{},
+		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared listing test repo fixture helper used across tests
- replace duplicated inline repo fixtures in listing/table tests with the shared helper
- extract shared active progress info formatting for pulling/pruning activities

## Testing
- mise x go@latest -- go test ./internal/ui/views/listing