### PR TITLE
refactor(listing): simplify sync command plumbing

### DIFF
--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -119,7 +119,7 @@ func (m *Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
 	cmds = append(cmds, scheduleInfoRotateTick(m.RotateEvery))
 	if !m.StartupPRSync {
-		cmds = append(cmds, m.startPullRequestSync(pullRequestSyncStartup)...)
+		cmds = append(cmds, m.startPullRequestSync(pullRequestSyncStartup))
 		m.StartupPRSync = true
 	}
 	cmds = append(cmds, m.BlockedSpinner.Tick)

--- a/internal/ui/views/listing/pull_request_sync.go
+++ b/internal/ui/views/listing/pull_request_sync.go
@@ -2,13 +2,13 @@ package listing
 
 import tea "charm.land/bubbletea/v2"
 
-func (m *Model) startPullRequestSync(trigger PullRequestSyncTrigger) []tea.Cmd {
+func (m *Model) startPullRequestSync(trigger PullRequestSyncTrigger) tea.Cmd {
 	m.PRSyncInFlight++
 
-	return []tea.Cmd{
+	return tea.Batch(
 		performPullRequestSync(m.Repositories, trigger),
 		m.PRSyncSpinner.Tick,
-	}
+	)
 }
 
 func (m *Model) completePullRequestSync() {

--- a/internal/ui/views/listing/pull_request_sync_test.go
+++ b/internal/ui/views/listing/pull_request_sync_test.go
@@ -8,18 +8,15 @@ import (
 	"charm.land/bubbles/v2/spinner"
 )
 
-func TestStartPullRequestSyncMarksInFlightAndReturnsCommands(t *testing.T) {
+func TestStartPullRequestSyncMarksInFlightAndReturnsCommand(t *testing.T) {
 	m := New(nil)
-	cmds := m.startPullRequestSync(pullRequestSyncManual)
+	cmd := m.startPullRequestSync(pullRequestSyncManual)
 
 	if m.PRSyncInFlight != 1 {
 		t.Fatalf("PRSyncInFlight = %d, want 1", m.PRSyncInFlight)
 	}
-	if len(cmds) != 2 {
-		t.Fatalf("len(cmds) = %d, want 2", len(cmds))
-	}
-	if cmds[0] == nil || cmds[1] == nil {
-		t.Fatal("expected non-nil sync commands")
+	if cmd == nil {
+		t.Fatal("expected non-nil sync command")
 	}
 }
 

--- a/internal/ui/views/listing/watch.go
+++ b/internal/ui/views/listing/watch.go
@@ -46,7 +46,7 @@ func (m *Model) toggleWatchMode() tea.Cmd {
 
 func (m *Model) startRefreshCycle(trigger PullRequestSyncTrigger) tea.Cmd {
 	var cmds []tea.Cmd
-	cmds = append(cmds, m.startPullRequestSync(trigger)...)
+	cmds = append(cmds, m.startPullRequestSync(trigger))
 	for i := range m.Repositories {
 		repo := &m.Repositories[i]
 		if repo.IsBusy() {


### PR DESCRIPTION
## Summary
- make `startPullRequestSync` return a single `tea.Cmd`
- batch the PR sync + spinner tick commands inside the helper
- simplify call sites in listing init and watch refresh cycle by removing spread append patterns
- update pull request sync unit test expectations for the new command shape

## Testing
- `mise exec -- go test ./internal/ui/views/listing`
