### PR TITLE
Make listing timer tests deterministic

### DIFF
--- a/internal/ui/views/listing/listing_test.go
+++ b/internal/ui/views/listing/listing_test.go
@@ -11,6 +11,10 @@ import (
 
 func TestUpdate_InfoRotateTick_IncrementsPhase(t *testing.T) {
 	m := New(nil)
+	var gotInterval time.Duration
+	withImmediateTickMock(t, func(interval time.Duration) {
+		gotInterval = interval
+	})
 	start := m.InfoPhase
 
 	newM, cmd := m.Update(infoRotateTickMsg{})
@@ -25,6 +29,9 @@ func TestUpdate_InfoRotateTick_IncrementsPhase(t *testing.T) {
 	}
 	if _, ok := cmd().(infoRotateTickMsg); !ok {
 		t.Fatal("rotate command did not return infoRotateTickMsg")
+	}
+	if gotInterval != m.RotateEvery {
+		t.Fatalf("scheduled interval = %s, want %s", gotInterval, m.RotateEvery)
 	}
 }
 

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -66,12 +66,14 @@ type pruneCompleteMsg struct {
 
 type infoRotateTickMsg struct{}
 
+var scheduleTick = tea.Tick
+
 func scheduleInfoRotateTick(interval time.Duration) tea.Cmd {
 	if interval <= 0 {
 		interval = 10 * time.Second
 	}
 
-	return tea.Tick(interval, func(time.Time) tea.Msg {
+	return scheduleTick(interval, func(time.Time) tea.Msg {
 		return infoRotateTickMsg{}
 	})
 }

--- a/internal/ui/views/listing/tick_test.go
+++ b/internal/ui/views/listing/tick_test.go
@@ -1,0 +1,26 @@
+package listing
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func withImmediateTickMock(t *testing.T, onSchedule func(interval time.Duration)) {
+	t.Helper()
+
+	original := scheduleTick
+	scheduleTick = func(interval time.Duration, fn func(time.Time) tea.Msg) tea.Cmd {
+		if onSchedule != nil {
+			onSchedule(interval)
+		}
+		return func() tea.Msg {
+			return fn(time.Time{})
+		}
+	}
+
+	t.Cleanup(func() {
+		scheduleTick = original
+	})
+}

--- a/internal/ui/views/listing/watch.go
+++ b/internal/ui/views/listing/watch.go
@@ -24,7 +24,7 @@ func scheduleWatchTick(interval time.Duration, token uint64) tea.Cmd {
 		interval = defaultWatchInterval
 	}
 
-	return tea.Tick(interval, func(time.Time) tea.Msg {
+	return scheduleTick(interval, func(time.Time) tea.Msg {
 		return watchTickMsg{Token: token}
 	})
 }

--- a/internal/ui/views/listing/watch_test.go
+++ b/internal/ui/views/listing/watch_test.go
@@ -12,6 +12,10 @@ import (
 
 func TestToggleWatchModeTurnsOnAndSchedulesTick(t *testing.T) {
 	m := New(nil)
+	var gotInterval time.Duration
+	withImmediateTickMock(t, func(interval time.Duration) {
+		gotInterval = interval
+	})
 	if m.WatchEnabled {
 		t.Fatal("watch mode should start disabled")
 	}
@@ -27,6 +31,9 @@ func TestToggleWatchModeTurnsOnAndSchedulesTick(t *testing.T) {
 	msg := cmd()
 	if _, ok := msg.(watchTickMsg); !ok {
 		t.Fatalf("command message = %T, want watchTickMsg", msg)
+	}
+	if gotInterval != m.WatchEvery {
+		t.Fatalf("scheduled interval = %s, want %s", gotInterval, m.WatchEvery)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace direct `tea.Tick` usage behind a package-level `scheduleTick` hook
- add a test helper to run tick callbacks immediately without wall-clock waiting
- update listing/watch timer tests to assert scheduled interval and emitted message deterministically

## Verification
- mise exec -- go test ./internal/ui/views/listing -count=1
- mise exec -- go test ./... -count=1
- mise exec -- go test ./internal/ui/views/listing -run 'TestUpdate_InfoRotateTick_IncrementsPhase|TestToggleWatchModeTurnsOnAndSchedulesTick' -count=30
