### PR TITLE
feat(ui): open repo PR list view from repo listing

### DIFF
--- a/internal/domain/pull_request_details.go
+++ b/internal/domain/pull_request_details.go
@@ -1,0 +1,20 @@
+package domain
+
+import "time"
+
+type PullRequestDetails struct {
+	Number    int
+	Title     string
+	IsMine    bool
+	UpdatedAt time.Time
+	Checks    PullRequestChecks
+}
+
+type PullRequestChecks struct {
+	Total   int
+	Passed  int
+	Waiting int
+	Running int
+	Failed  int
+	Skipped int
+}

--- a/internal/git/pull_request_details.go
+++ b/internal/git/pull_request_details.go
@@ -1,0 +1,145 @@
+package git
+
+import (
+	"encoding/json"
+	"errors"
+	"fresh/internal/config"
+	"fresh/internal/domain"
+	"sort"
+	"strings"
+	"time"
+)
+
+var ErrPullRequestDetailsUnsupported = errors.New("pull requests are currently only supported for GitHub repositories")
+
+type ghRepoPullRequestRow struct {
+	Number           int    `json:"number"`
+	Title            string `json:"title"`
+	UpdatedAt        string `json:"updatedAt"`
+	StatusCheckRollup []ghStatusCheckContext `json:"statusCheckRollup"`
+	Author           struct {
+		Login string `json:"login"`
+	} `json:"author"`
+}
+
+type ghStatusCheckContext struct {
+	Conclusion string `json:"conclusion"`
+	Status     string `json:"status"`
+	State      string `json:"state"`
+}
+
+func GetRepositoryPullRequests(repo domain.Repository) ([]domain.PullRequestDetails, error) {
+	owner, name, ok := parseGitHubRemote(repo.RemoteURL)
+	if !ok {
+		return nil, ErrPullRequestDetailsUnsupported
+	}
+
+	ownerRepo := owner + "/" + name
+	args := []string{
+		"pr", "list",
+		"--repo", ownerRepo,
+		"--state", "open",
+		"--limit", "200",
+		"--json", "number,title,updatedAt,author,statusCheckRollup",
+	}
+
+	cmd := createCommand(config.DefaultConfig().Timeout.Default, "gh", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, normalizeGhError(err)
+	}
+
+	var rows []ghRepoPullRequestRow
+	if err := json.Unmarshal(output, &rows); err != nil {
+		return nil, err
+	}
+
+	currentUser := queryGitHubLogin()
+	pullRequests := make([]domain.PullRequestDetails, 0, len(rows))
+	for _, row := range rows {
+		updatedAt, _ := time.Parse(time.RFC3339, row.UpdatedAt)
+		pullRequests = append(pullRequests, domain.PullRequestDetails{
+			Number:    row.Number,
+			Title:     row.Title,
+			IsMine:    currentUser != "" && strings.EqualFold(strings.TrimSpace(row.Author.Login), currentUser),
+			UpdatedAt: updatedAt,
+			Checks:    summarizePullRequestChecks(row.StatusCheckRollup),
+		})
+	}
+
+	sort.Slice(pullRequests, func(i, j int) bool {
+		if pullRequests[i].IsMine != pullRequests[j].IsMine {
+			return pullRequests[i].IsMine
+		}
+		if !pullRequests[i].UpdatedAt.Equal(pullRequests[j].UpdatedAt) {
+			return pullRequests[i].UpdatedAt.After(pullRequests[j].UpdatedAt)
+		}
+		return pullRequests[i].Number > pullRequests[j].Number
+	})
+
+	return pullRequests, nil
+}
+
+func queryGitHubLogin() string {
+	cmd := createCommand(config.DefaultConfig().Timeout.Default, "gh", "api", "user", "--jq", ".login")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func summarizePullRequestChecks(contexts []ghStatusCheckContext) domain.PullRequestChecks {
+	summary := domain.PullRequestChecks{Total: len(contexts)}
+	for _, context := range contexts {
+		switch classifyCheckContext(context) {
+		case "passed":
+			summary.Passed++
+		case "running":
+			summary.Running++
+		case "failed":
+			summary.Failed++
+		case "skipped":
+			summary.Skipped++
+		default:
+			summary.Waiting++
+		}
+	}
+	return summary
+}
+
+func classifyCheckContext(context ghStatusCheckContext) string {
+	conclusion := strings.ToUpper(strings.TrimSpace(context.Conclusion))
+	switch conclusion {
+	case "SUCCESS":
+		return "passed"
+	case "SKIPPED", "NEUTRAL":
+		return "skipped"
+	case "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
+		return "failed"
+	}
+
+	status := strings.ToUpper(strings.TrimSpace(context.Status))
+	if status != "" && status != "COMPLETED" {
+		if status == "IN_PROGRESS" {
+			return "running"
+		}
+		return "waiting"
+	}
+
+	state := strings.ToUpper(strings.TrimSpace(context.State))
+	switch state {
+	case "SUCCESS":
+		return "passed"
+	case "FAILURE", "ERROR":
+		return "failed"
+	case "PENDING", "EXPECTED":
+		return "waiting"
+	}
+
+	if status == "COMPLETED" {
+		return "passed"
+	}
+
+	return "waiting"
+}

--- a/internal/git/pull_request_details_test.go
+++ b/internal/git/pull_request_details_test.go
@@ -1,0 +1,90 @@
+package git
+
+import "testing"
+
+func TestClassifyCheckContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		context ghStatusCheckContext
+		want    string
+	}{
+		{
+			name:    "success conclusion is passed",
+			context: ghStatusCheckContext{Conclusion: "SUCCESS"},
+			want:    "passed",
+		},
+		{
+			name:    "failed conclusion is failed",
+			context: ghStatusCheckContext{Conclusion: "FAILURE"},
+			want:    "failed",
+		},
+		{
+			name:    "skipped conclusion is skipped",
+			context: ghStatusCheckContext{Conclusion: "SKIPPED"},
+			want:    "skipped",
+		},
+		{
+			name:    "in progress status is running",
+			context: ghStatusCheckContext{Status: "IN_PROGRESS"},
+			want:    "running",
+		},
+		{
+			name:    "queued status is waiting",
+			context: ghStatusCheckContext{Status: "QUEUED"},
+			want:    "waiting",
+		},
+		{
+			name:    "pending state is waiting",
+			context: ghStatusCheckContext{State: "PENDING"},
+			want:    "waiting",
+		},
+		{
+			name:    "failure state is failed",
+			context: ghStatusCheckContext{State: "FAILURE"},
+			want:    "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyCheckContext(tt.context)
+			if got != tt.want {
+				t.Fatalf("classifyCheckContext(%+v) = %q, want %q", tt.context, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizePullRequestChecks(t *testing.T) {
+	t.Parallel()
+
+	summary := summarizePullRequestChecks([]ghStatusCheckContext{
+		{Conclusion: "SUCCESS"},
+		{Status: "IN_PROGRESS"},
+		{Status: "QUEUED"},
+		{Conclusion: "FAILURE"},
+		{Conclusion: "SKIPPED"},
+	})
+
+	if summary.Total != 5 {
+		t.Fatalf("total = %d, want 5", summary.Total)
+	}
+	if summary.Passed != 1 {
+		t.Fatalf("passed = %d, want 1", summary.Passed)
+	}
+	if summary.Running != 1 {
+		t.Fatalf("running = %d, want 1", summary.Running)
+	}
+	if summary.Waiting != 1 {
+		t.Fatalf("waiting = %d, want 1", summary.Waiting)
+	}
+	if summary.Failed != 1 {
+		t.Fatalf("failed = %d, want 1", summary.Failed)
+	}
+	if summary.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", summary.Skipped)
+	}
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"fresh/internal/domain"
 	"fresh/internal/notifications"
 	"fresh/internal/ui/views/listing"
+	"fresh/internal/ui/views/pullrequests"
 	"fresh/internal/ui/views/scanning"
 
 	tea "charm.land/bubbletea/v2"
@@ -13,14 +15,17 @@ type CurrentView int
 const (
 	ScanningView CurrentView = iota
 	RepoListView
+	RepoPRListView
 )
 
 type MainModel struct {
-	currentView   CurrentView
-	scanningView  *scanning.Model
-	listingView   *listing.Model
-	notifier      *notifications.Notifier
-	width, height int
+	currentView       CurrentView
+	scanningView      *scanning.Model
+	listingView       *listing.Model
+	pullRequestsView  *pullrequests.Model
+	pullRequestCache  map[string][]domain.PullRequestDetails
+	notifier          *notifications.Notifier
+	width, height     int
 }
 
 func New(scanDir string, notifier ...*notifications.Notifier) *MainModel {
@@ -30,9 +35,10 @@ func New(scanDir string, notifier ...*notifications.Notifier) *MainModel {
 	}
 
 	return &MainModel{
-		currentView:  ScanningView,
-		scanningView: scanning.New(scanDir),
-		notifier:     injectedNotifier,
+		currentView:      ScanningView,
+		scanningView:     scanning.New(scanDir),
+		pullRequestCache: make(map[string][]domain.PullRequestDetails),
+		notifier:         injectedNotifier,
 	}
 }
 
@@ -42,6 +48,8 @@ func (m *MainModel) Init() tea.Cmd {
 		return m.scanningView.Init()
 	case RepoListView:
 		return m.listingView.Init()
+	case RepoPRListView:
+		return m.pullRequestsView.Init()
 	default:
 		return nil
 	}
@@ -64,6 +72,25 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.listingView = listing.NewWithNotifier(msg.Repos, m.notifier)
 		m.listingView.SetSize(m.width, m.height)
 		return m, m.listingView.Init()
+
+	case listing.OpenPullRequestsMsg:
+		cached := append([]domain.PullRequestDetails(nil), m.pullRequestCache[msg.Repo.Path]...)
+		m.currentView = RepoPRListView
+		m.pullRequestsView = pullrequests.New(msg.Repo, cached)
+		m.pullRequestsView.SetSize(m.width, m.height)
+		return m, m.pullRequestsView.Init()
+
+	case pullrequests.BackToRepoListMsg:
+		m.currentView = RepoListView
+		if m.listingView != nil {
+			m.listingView.SetSize(m.width, m.height)
+		}
+		return m, nil
+
+	case pullrequests.PullRequestsLoadedMsg:
+		if msg.RepoPath != "" && msg.Error == "" {
+			m.pullRequestCache[msg.RepoPath] = append([]domain.PullRequestDetails(nil), msg.PullRequests...)
+		}
 	}
 
 	switch m.currentView {
@@ -71,6 +98,10 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.scanningView, cmd = m.scanningView.Update(msg)
 	case RepoListView:
 		m.listingView, cmd = m.listingView.Update(msg)
+	case RepoPRListView:
+		if m.pullRequestsView != nil {
+			m.pullRequestsView, cmd = m.pullRequestsView.Update(msg)
+		}
 	}
 	cmds = append(cmds, cmd)
 	return m, tea.Batch(cmds...)
@@ -86,6 +117,11 @@ func (m *MainModel) View() tea.View {
 			return v
 		}
 		v.SetContent(m.listingView.View())
+	case RepoPRListView:
+		if m.pullRequestsView == nil {
+			return v
+		}
+		v.SetContent(m.pullRequestsView.View())
 	}
 	return v
 }

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/listing"
+	"fresh/internal/ui/views/pullrequests"
 	"fresh/internal/ui/views/scanning"
 	"testing"
 
@@ -118,6 +119,78 @@ func TestMainModel_DelegatesKeyMsgToListingInRepoListView(t *testing.T) {
 	}
 }
 
+func TestMainModel_EnterTransitionsToPullRequestView(t *testing.T) {
+	t.Parallel()
+
+	m := New(t.TempDir())
+
+	repos := []domain.Repository{
+		{
+			Name:        "repo-a",
+			Path:        "/tmp/repo-a",
+			RemoteURL:   "https://github.com/octo/repo-a",
+			Activity:    domain.IdleActivity{},
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+		},
+	}
+	m.Update(scanning.ScanFinishedMsg{Repos: repos})
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: '\r'})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd after enter")
+	}
+
+	result, _ := m.Update(cmd())
+	model := result.(*MainModel)
+
+	if model.currentView != RepoPRListView {
+		t.Errorf("view after enter = %d, want RepoPRListView (%d)", model.currentView, RepoPRListView)
+	}
+	if model.pullRequestsView == nil {
+		t.Fatal("expected pullRequestsView to be initialized")
+	}
+	if model.pullRequestsView.Repo.Path != repos[0].Path {
+		t.Errorf("pull request view repo path = %q, want %q", model.pullRequestsView.Repo.Path, repos[0].Path)
+	}
+}
+
+func TestMainModel_EscapeTransitionsBackToListingView(t *testing.T) {
+	t.Parallel()
+
+	m := New(t.TempDir())
+
+	repos := []domain.Repository{
+		{
+			Name:        "repo-a",
+			Path:        "/tmp/repo-a",
+			RemoteURL:   "https://github.com/octo/repo-a",
+			Activity:    domain.IdleActivity{},
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+		},
+	}
+	m.Update(scanning.ScanFinishedMsg{Repos: repos})
+	_, openCmd := m.Update(tea.KeyPressMsg{Code: '\r'})
+	if openCmd == nil {
+		t.Fatal("expected non-nil open command after enter")
+	}
+	m.Update(openCmd())
+
+	_, backCmd := m.Update(tea.KeyPressMsg{Code: 27})
+	if backCmd == nil {
+		t.Fatal("expected non-nil back command after escape")
+	}
+	result, _ := m.Update(backCmd())
+	model := result.(*MainModel)
+
+	if model.currentView != RepoListView {
+		t.Errorf("view after esc = %d, want RepoListView (%d)", model.currentView, RepoListView)
+	}
+}
+
 func TestMainModel_ViewInScanningMode(t *testing.T) {
 	t.Parallel()
 
@@ -183,4 +256,5 @@ func TestMainModel_DefaultViewReturnsEmpty(t *testing.T) {
 // Verify that unused imports don't cause issues — these are needed for
 // the test to compile but the linter may flag them without explicit use.
 var _ = listing.New
+var _ = pullrequests.New
 var _ = scanning.ScanFinishedMsg{}

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -144,3 +144,9 @@ func performPullRequestSync(repos []domain.Repository, trigger PullRequestSyncTr
 		return PullRequestStatesUpdatedMsg{States: states, Trigger: trigger}
 	}
 }
+
+func openPullRequestsView(repo domain.Repository) tea.Cmd {
+	return func() tea.Msg {
+		return OpenPullRequestsMsg{Repo: repo}
+	}
+}

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -18,6 +18,7 @@ type listKeyMap struct {
 	watch        key.Binding
 	pullAll      key.Binding
 	pruneAll     key.Binding
+	openPRs      key.Binding
 	alert        key.Binding
 	toggleLegend key.Binding
 }
@@ -39,6 +40,10 @@ func newListKeyMap() *listKeyMap {
 		pruneAll: key.NewBinding(
 			key.WithKeys("b"),
 			key.WithHelp("b", "prune merged branches"),
+		),
+		openPRs: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "view pull requests"),
 		),
 		alert: key.NewBinding(
 			key.WithKeys("a"),
@@ -175,6 +180,12 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 				}
 			}
 			return m, tea.Batch(cmds...)
+
+		case key.Matches(msg, m.Keys.openPRs) || msg.String() == "enter" || msg.Code == '\r':
+			if len(m.Repositories) == 0 || m.Cursor < 0 || m.Cursor >= len(m.Repositories) {
+				return m, nil
+			}
+			return m, openPullRequestsView(m.Repositories[m.Cursor])
 
 		case key.Matches(msg, m.Keys.toggleLegend):
 			m.ShowLegend = !m.ShowLegend
@@ -383,6 +394,7 @@ func (m *Model) buildFooter() string {
 
 	hotkeys := []string{
 		"↑/↓ navigate",
+		"enter view PRs",
 		"r refresh",
 		watchStatus,
 		"p pull all updates",

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -26,6 +26,10 @@ type PullRequestStatesUpdatedMsg struct {
 	Trigger PullRequestSyncTrigger
 }
 
+type OpenPullRequestsMsg struct {
+	Repo domain.Repository
+}
+
 type pullLineMsg struct {
 	Index int
 	line  string

--- a/internal/ui/views/pullrequests/commands.go
+++ b/internal/ui/views/pullrequests/commands.go
@@ -1,0 +1,31 @@
+package pullrequests
+
+import (
+	"errors"
+
+	"fresh/internal/domain"
+	"fresh/internal/git"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func performPullRequestLoad(repo domain.Repository) tea.Cmd {
+	return func() tea.Msg {
+		rows, err := git.GetRepositoryPullRequests(repo)
+		msg := PullRequestsLoadedMsg{
+			RepoPath:     repo.Path,
+			PullRequests: rows,
+		}
+		if err != nil {
+			msg.Error = err.Error()
+			msg.Unsupported = errors.Is(err, git.ErrPullRequestDetailsUnsupported)
+		}
+		return msg
+	}
+}
+
+func backToRepoList() tea.Cmd {
+	return func() tea.Msg {
+		return BackToRepoListMsg{}
+	}
+}

--- a/internal/ui/views/pullrequests/layout.go
+++ b/internal/ui/views/pullrequests/layout.go
@@ -1,0 +1,83 @@
+package pullrequests
+
+type ColumnLayout struct {
+	TitleWidth   int
+	CheckBarWidth int
+	SummaryWidth int
+}
+
+const (
+	SelectorWidth  = 2
+	NumberWidth    = 7
+	DefaultTitleWidth = 44
+	MinTitleWidth  = 18
+	MaxTitleWidth  = 70
+	DefaultBarWidth = 26
+	MinBarWidth    = 14
+	MaxBarWidth    = 32
+	DefaultSummaryWidth = 22
+	MinSummaryWidth = 16
+	MaxSummaryWidth = 30
+	InterColumnGap = 2
+)
+
+func calculateColumnLayout(width int) ColumnLayout {
+	titleWidth := DefaultTitleWidth
+	barWidth := DefaultBarWidth
+	summaryWidth := DefaultSummaryWidth
+
+	if width <= 0 {
+		return ColumnLayout{
+			TitleWidth:    titleWidth,
+			CheckBarWidth: barWidth,
+			SummaryWidth:  summaryWidth,
+		}
+	}
+
+	fixed := SelectorWidth + NumberWidth + (4 * InterColumnGap)
+	available := width - fixed
+	if available <= MinTitleWidth+MinBarWidth+MinSummaryWidth {
+		return ColumnLayout{
+			TitleWidth:    MinTitleWidth,
+			CheckBarWidth: MinBarWidth,
+			SummaryWidth:  MinSummaryWidth,
+		}
+	}
+
+	titleWidth = clamp(available/2, MinTitleWidth, MaxTitleWidth)
+	remaining := available - titleWidth
+	barWidth = clamp((remaining*3)/5, MinBarWidth, MaxBarWidth)
+	summaryWidth = clamp(remaining-barWidth, MinSummaryWidth, MaxSummaryWidth)
+
+	for titleWidth+barWidth+summaryWidth > available {
+		if titleWidth > MinTitleWidth {
+			titleWidth--
+			continue
+		}
+		if barWidth > MinBarWidth {
+			barWidth--
+			continue
+		}
+		if summaryWidth > MinSummaryWidth {
+			summaryWidth--
+			continue
+		}
+		break
+	}
+
+	return ColumnLayout{
+		TitleWidth:    titleWidth,
+		CheckBarWidth: barWidth,
+		SummaryWidth:  summaryWidth,
+	}
+}
+
+func clamp(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/internal/ui/views/pullrequests/messages.go
+++ b/internal/ui/views/pullrequests/messages.go
@@ -1,0 +1,30 @@
+package pullrequests
+
+import (
+	"time"
+
+	"fresh/internal/domain"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+type BackToRepoListMsg struct{}
+
+type PullRequestsLoadedMsg struct {
+	RepoPath    string
+	PullRequests []domain.PullRequestDetails
+	Unsupported bool
+	Error       string
+}
+
+type pulseTickMsg struct{}
+
+func schedulePulseTick(interval time.Duration) tea.Cmd {
+	if interval <= 0 {
+		interval = 350 * time.Millisecond
+	}
+
+	return tea.Tick(interval, func(time.Time) tea.Msg {
+		return pulseTickMsg{}
+	})
+}

--- a/internal/ui/views/pullrequests/pullrequests.go
+++ b/internal/ui/views/pullrequests/pullrequests.go
@@ -1,0 +1,199 @@
+package pullrequests
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"fresh/internal/domain"
+	"fresh/internal/ui/views/common"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type prListKeyMap struct {
+	refresh key.Binding
+	back    key.Binding
+}
+
+func newPRListKeyMap() *prListKeyMap {
+	return &prListKeyMap{
+		refresh: key.NewBinding(
+			key.WithKeys("r"),
+			key.WithHelp("r", "refresh pull requests"),
+		),
+		back: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "back to repositories"),
+		),
+	}
+}
+
+type Model struct {
+	Repo         domain.Repository
+	PullRequests []domain.PullRequestDetails
+	Cursor       int
+	Keys         *prListKeyMap
+	layout       ColumnLayout
+	width, height int
+	Loading      bool
+	Unsupported  bool
+	LoadError    string
+	PulseOn      bool
+	PulseEvery   time.Duration
+	Spinner      spinner.Model
+}
+
+func New(repo domain.Repository, cached []domain.PullRequestDetails) *Model {
+	rows := append([]domain.PullRequestDetails(nil), cached...)
+
+	return &Model{
+		Repo:         repo,
+		PullRequests: rows,
+		Cursor:       0,
+		Keys:         newPRListKeyMap(),
+		layout:       calculateColumnLayout(0),
+		Loading:      true,
+		Unsupported:  false,
+		LoadError:    "",
+		PulseOn:      false,
+		PulseEvery:   350 * time.Millisecond,
+		Spinner:      common.NewPullRequestSpinner(),
+	}
+}
+
+func (m *Model) SetSize(width, height int) {
+	m.width = width
+	m.height = height
+	m.layout = calculateColumnLayout(width)
+}
+
+func (m *Model) Init() tea.Cmd {
+	return tea.Batch(
+		schedulePulseTick(m.PulseEvery),
+		performPullRequestLoad(m.Repo),
+		m.Spinner.Tick,
+	)
+}
+
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.SetSize(msg.Width, msg.Height)
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.Keys.back) || msg.String() == "esc" || msg.Code == 27:
+			return m, backToRepoList()
+		case key.Matches(msg, m.Keys.refresh):
+			m.Loading = true
+			m.Unsupported = false
+			m.LoadError = ""
+			return m, tea.Batch(performPullRequestLoad(m.Repo), m.Spinner.Tick)
+		case msg.String() == "up", msg.String() == "k":
+			if m.Cursor > 0 {
+				m.Cursor--
+			}
+		case msg.String() == "down", msg.String() == "j":
+			if m.Cursor < len(m.PullRequests)-1 {
+				m.Cursor++
+			}
+		}
+
+	case PullRequestsLoadedMsg:
+		if msg.RepoPath != m.Repo.Path {
+			return m, nil
+		}
+
+		m.Loading = false
+		m.Unsupported = msg.Unsupported
+		m.LoadError = msg.Error
+		if msg.Error == "" {
+			m.PullRequests = msg.PullRequests
+		} else if msg.Unsupported {
+			m.PullRequests = nil
+		}
+
+		if len(m.PullRequests) == 0 {
+			m.Cursor = 0
+		} else if m.Cursor >= len(m.PullRequests) {
+			m.Cursor = len(m.PullRequests) - 1
+		}
+
+	case pulseTickMsg:
+		m.PulseOn = !m.PulseOn
+		return m, schedulePulseTick(m.PulseEvery)
+
+	case spinner.TickMsg:
+		if m.Loading {
+			var cmd tea.Cmd
+			m.Spinner, cmd = m.Spinner.Update(msg)
+			return m, cmd
+		}
+	}
+
+	return m, nil
+}
+
+func (m *Model) View() string {
+	var s strings.Builder
+
+	title := fmt.Sprintf("\nPull requests for %s\n", m.Repo.Name)
+	s.WriteString(common.HeaderStyle.Render(title))
+
+	if m.Unsupported {
+		msg := "Pull requests are currently only supported for GitHub repositories."
+		s.WriteString("\n")
+		s.WriteString(lipgloss.NewStyle().Foreground(common.SubtleGray).Render(msg))
+		s.WriteString("\n\n")
+		s.WriteString(m.buildFooter())
+		return s.String()
+	}
+
+	if len(m.PullRequests) == 0 {
+		s.WriteString("\n")
+		switch {
+		case m.Loading:
+			s.WriteString(common.TextGrey.Render(m.Spinner.View() + " Loading pull requests..."))
+		case m.LoadError != "":
+			s.WriteString(lipgloss.NewStyle().Foreground(common.SubtleRed).Render("Failed to load pull requests: " + m.LoadError))
+		default:
+			s.WriteString(common.TextGrey.Render("No open pull requests."))
+		}
+		s.WriteString("\n\n")
+		s.WriteString(m.buildFooter())
+		return s.String()
+	}
+
+	s.WriteString(RenderTable(m.PullRequests, m.Cursor, m.layout, m.PulseOn))
+	s.WriteString("\n")
+
+	if m.Loading {
+		s.WriteString("\n")
+		s.WriteString(common.TextGrey.Render(m.Spinner.View() + " Refreshing pull requests in background..."))
+	}
+	if m.LoadError != "" {
+		s.WriteString("\n")
+		s.WriteString(lipgloss.NewStyle().Foreground(common.SubtleRed).Render("Refresh error: " + m.LoadError))
+	}
+
+	s.WriteString("\n\n")
+	s.WriteString(m.buildFooter())
+
+	return s.String()
+}
+
+func (m *Model) buildFooter() string {
+	legend := "my PRs highlighted in blue"
+	hotkeys := []string{
+		"↑/↓ navigate",
+		"r refresh",
+		"esc back",
+		"q quit",
+	}
+	return common.FooterStyle.Render(strings.Join(hotkeys, "  •  ") + "  •  " + legend)
+}

--- a/internal/ui/views/pullrequests/pullrequests_test.go
+++ b/internal/ui/views/pullrequests/pullrequests_test.go
@@ -1,0 +1,83 @@
+package pullrequests
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"fresh/internal/domain"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestUpdate_PullRequestsLoadedMsg_UpdatesRowsAndStopsLoading(t *testing.T) {
+	t.Parallel()
+
+	repo := domain.Repository{Name: "demo", Path: "/tmp/demo", RemoteURL: "https://github.com/octo/demo"}
+	m := New(repo, nil)
+	m.Loading = true
+
+	rows := []domain.PullRequestDetails{
+		{
+			Number:    42,
+			Title:     "Fix flaky test",
+			IsMine:    true,
+			UpdatedAt: time.Now(),
+			Checks: domain.PullRequestChecks{
+				Total:   7,
+				Passed:  5,
+				Failed:  1,
+				Skipped: 1,
+			},
+		},
+	}
+
+	newM, cmd := m.Update(PullRequestsLoadedMsg{RepoPath: repo.Path, PullRequests: rows})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd, got non-nil")
+	}
+	if newM.Loading {
+		t.Fatalf("expected loading=false after loaded message")
+	}
+	if len(newM.PullRequests) != 1 {
+		t.Fatalf("rows = %d, want 1", len(newM.PullRequests))
+	}
+	if newM.PullRequests[0].Number != 42 {
+		t.Fatalf("row number = %d, want 42", newM.PullRequests[0].Number)
+	}
+}
+
+func TestUpdate_EscapeReturnsBackCommand(t *testing.T) {
+	t.Parallel()
+
+	repo := domain.Repository{Name: "demo", Path: "/tmp/demo", RemoteURL: "https://github.com/octo/demo"}
+	m := New(repo, nil)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 27})
+	if cmd == nil {
+		t.Fatal("expected back command on escape")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(BackToRepoListMsg); !ok {
+		t.Fatalf("command message = %T, want BackToRepoListMsg", msg)
+	}
+}
+
+func TestBuildCheckSummary_CompleteAndFailing(t *testing.T) {
+	t.Parallel()
+
+	summary := buildCheckSummary(domain.PullRequestChecks{
+		Total:   7,
+		Passed:  5,
+		Failed:  1,
+		Skipped: 1,
+	}, 80)
+
+	if !strings.Contains(summary, "6/7 complete") {
+		t.Fatalf("summary = %q, want complete count", summary)
+	}
+	if !strings.Contains(summary, "1 failing") {
+		t.Fatalf("summary = %q, want failing count", summary)
+	}
+}

--- a/internal/ui/views/pullrequests/table.go
+++ b/internal/ui/views/pullrequests/table.go
@@ -1,0 +1,255 @@
+package pullrequests
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"fresh/internal/domain"
+	"fresh/internal/ui/views/common"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/table"
+)
+
+func RenderTable(rows []domain.PullRequestDetails, cursor int, layout ColumnLayout, pulse bool) string {
+	headers := []string{"", "#", "Title", "Checks", "Summary"}
+
+	renderedRows := make([][]string, len(rows))
+	for i, row := range rows {
+		renderedRows[i] = pullRequestToRow(row, i == cursor, layout, pulse)
+	}
+
+	t := table.New().
+		Border(lipgloss.HiddenBorder()).
+		Headers(headers...).
+		Rows(renderedRows...).
+		BorderStyle(common.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return common.TableHeaderStyle
+			}
+			return lipgloss.NewStyle()
+		})
+
+	return t.Render()
+}
+
+func pullRequestToRow(row domain.PullRequestDetails, selected bool, layout ColumnLayout, pulse bool) []string {
+	return []string{
+		buildSelector(selected),
+		buildNumber(row.Number, row.IsMine),
+		buildTitle(row.Title, row.IsMine, selected, layout.TitleWidth),
+		buildCheckBar(row.Checks, layout.CheckBarWidth, pulse),
+		buildCheckSummary(row.Checks, layout.SummaryWidth),
+	}
+}
+
+func buildSelector(selected bool) string {
+	style := common.SelectorStyle.Width(SelectorWidth)
+	if selected {
+		return style.Render(common.IconSelector)
+	}
+	return style.Render(" ")
+}
+
+func buildNumber(number int, mine bool) string {
+	style := lipgloss.NewStyle().
+		Width(NumberWidth).
+		MaxWidth(NumberWidth).
+		AlignHorizontal(lipgloss.Left)
+	if mine {
+		style = style.Foreground(common.Blue).Bold(true)
+	} else {
+		style = style.Foreground(common.TextSecondary)
+	}
+	return style.Render(fmt.Sprintf("#%d", number))
+}
+
+func buildTitle(title string, mine bool, selected bool, width int) string {
+	if width < 1 {
+		width = 1
+	}
+
+	displayTitle := title
+	if lipgloss.Width(title) > width {
+		displayTitle = common.TruncateWithEllipsis(title, width)
+	}
+
+	style := lipgloss.NewStyle().
+		Width(width).
+		MaxWidth(width).
+		AlignHorizontal(lipgloss.Left)
+	if mine {
+		style = style.Foreground(common.Blue)
+	} else {
+		style = style.Foreground(common.TextPrimary)
+	}
+	if selected {
+		style = style.Bold(true)
+	}
+
+	return style.Render(displayTitle)
+}
+
+func buildCheckBar(checks domain.PullRequestChecks, width int, pulse bool) string {
+	if width < 1 {
+		width = 1
+	}
+
+	baseStyle := lipgloss.NewStyle().
+		Width(width).
+		MaxWidth(width).
+		AlignHorizontal(lipgloss.Left)
+
+	if checks.Total <= 0 {
+		return baseStyle.Foreground(common.SubtleGray).Render(strings.Repeat("·", width))
+	}
+
+	counts := []int{
+		checks.Passed,
+		checks.Waiting,
+		checks.Running,
+		checks.Failed,
+		checks.Skipped,
+	}
+	scaled := scaleCountsToWidth(counts, width)
+
+	runningChar := "▒"
+	if pulse {
+		runningChar = "▓"
+	}
+
+	segments := []struct {
+		Count int
+		Style lipgloss.Style
+		Char  string
+	}{
+		{Count: scaled[0], Style: lipgloss.NewStyle().Foreground(common.Green), Char: "█"},
+		{Count: scaled[1], Style: lipgloss.NewStyle().Foreground(common.Yellow), Char: "░"},
+		{Count: scaled[2], Style: lipgloss.NewStyle().Foreground(common.Yellow), Char: runningChar},
+		{Count: scaled[3], Style: lipgloss.NewStyle().Foreground(common.Red), Char: "█"},
+		{Count: scaled[4], Style: lipgloss.NewStyle().Foreground(common.SubtleGray), Char: "█"},
+	}
+
+	var bar strings.Builder
+	for _, segment := range segments {
+		if segment.Count <= 0 {
+			continue
+		}
+		bar.WriteString(segment.Style.Render(strings.Repeat(segment.Char, segment.Count)))
+	}
+
+	barText := bar.String()
+	if lipgloss.Width(barText) < width {
+		barText += lipgloss.NewStyle().Foreground(common.SubtleGray).Render(strings.Repeat("·", width-lipgloss.Width(barText)))
+	}
+
+	return baseStyle.Render(barText)
+}
+
+func buildCheckSummary(checks domain.PullRequestChecks, width int) string {
+	style := lipgloss.NewStyle().
+		Width(width).
+		MaxWidth(width).
+		AlignHorizontal(lipgloss.Left).
+		Foreground(common.TextSecondary)
+
+	if checks.Total <= 0 {
+		return style.Foreground(common.SubtleGray).Render("No checks")
+	}
+
+	complete := checks.Passed + checks.Failed + checks.Skipped
+	summary := fmt.Sprintf("%d/%d complete", complete, checks.Total)
+	switch {
+	case checks.Failed > 0:
+		summary += fmt.Sprintf(" • %d failing", checks.Failed)
+	case checks.Running > 0:
+		summary += fmt.Sprintf(" • %d running", checks.Running)
+	case checks.Waiting > 0:
+		summary += fmt.Sprintf(" • %d waiting", checks.Waiting)
+	}
+
+	if lipgloss.Width(summary) > width {
+		summary = common.TruncateWithEllipsis(summary, width)
+	}
+
+	return style.Render(summary)
+}
+
+func scaleCountsToWidth(counts []int, width int) []int {
+	scaled := make([]int, len(counts))
+	if width <= 0 {
+		return scaled
+	}
+
+	total := 0
+	for _, count := range counts {
+		if count > 0 {
+			total += count
+		}
+	}
+	if total <= 0 {
+		return scaled
+	}
+
+	remainders := make([]float64, len(counts))
+	used := 0
+	for i, count := range counts {
+		if count <= 0 {
+			continue
+		}
+		raw := (float64(count) * float64(width)) / float64(total)
+		scaled[i] = int(math.Floor(raw))
+		remainders[i] = raw - float64(scaled[i])
+		used += scaled[i]
+	}
+
+	for used < width {
+		index := indexOfLargestRemainder(remainders, counts)
+		if index < 0 {
+			break
+		}
+		scaled[index]++
+		remainders[index] = 0
+		used++
+	}
+
+	for used > width {
+		index := indexOfLargestSegment(scaled)
+		if index < 0 {
+			break
+		}
+		scaled[index]--
+		used--
+	}
+
+	return scaled
+}
+
+func indexOfLargestRemainder(remainders []float64, counts []int) int {
+	bestIndex := -1
+	best := -1.0
+	for i := range remainders {
+		if counts[i] <= 0 {
+			continue
+		}
+		if remainders[i] > best {
+			best = remainders[i]
+			bestIndex = i
+		}
+	}
+	return bestIndex
+}
+
+func indexOfLargestSegment(counts []int) int {
+	bestIndex := -1
+	best := 0
+	for i, count := range counts {
+		if count > best {
+			best = count
+			bestIndex = i
+		}
+	}
+	return bestIndex
+}

--- a/internal/ui/views/pullrequests/table.go
+++ b/internal/ui/views/pullrequests/table.go
@@ -159,7 +159,7 @@ func buildCheckSummary(checks domain.PullRequestChecks, width int) string {
 		return style.Foreground(common.SubtleGray).Render("No checks")
 	}
 
-	complete := checks.Passed + checks.Failed + checks.Skipped
+	complete := checks.Passed + checks.Skipped
 	summary := fmt.Sprintf("%d/%d complete", complete, checks.Total)
 	switch {
 	case checks.Failed > 0:


### PR DESCRIPTION
## Summary
- add a new pull requests view package under internal/ui/views/pullrequests
- open the selected repo PR view from listing on Enter and return with Escape
- render PR rows with number, title, and segmented checks bar (pass/waiting/running/fail/skipped)
- highlight my PRs, sort by mine first then updatedAt recency
- show unsupported state for non-GitHub remotes and support cache + background refresh

## Notes
- could not run gofmt/go test in this environment because Go toolchain is not installed
