### PR TITLE
feat: add PR watchlist tracker for notification dedupe

### DIFF
--- a/internal/git/pull_requests.go
+++ b/internal/git/pull_requests.go
@@ -84,10 +84,6 @@ func SetPullRequestService(service PullRequestService) {
 	pullRequestService = service
 }
 
-func GetPullRequestStates(repos []domain.Repository) map[string]domain.PullRequestState {
-	return pullRequestService.GetPullRequestSync(repos).States
-}
-
 func GetPullRequestSync(repos []domain.Repository) PullRequestSync {
 	return pullRequestService.GetPullRequestSync(repos)
 }

--- a/internal/git/pull_requests.go
+++ b/internal/git/pull_requests.go
@@ -5,16 +5,22 @@ import (
 	"fmt"
 	"fresh/internal/config"
 	"fresh/internal/domain"
+	"fresh/internal/pullrequests"
 	"os/exec"
 	"sort"
 	"strings"
 )
 
 type PullRequestService interface {
-	GetPullRequestStates(repos []domain.Repository) map[string]domain.PullRequestState
+	GetPullRequestSync(repos []domain.Repository) PullRequestSync
 }
 
 type GhPullRequestService struct{}
+
+type PullRequestSync struct {
+	States  map[string]domain.PullRequestState
+	Tracked []pullrequests.Snapshot
+}
 
 type myPullRequestSummary struct {
 	MyOpen    int
@@ -42,6 +48,7 @@ type gqlPullRequestNode struct {
 	Repository struct {
 		NameWithOwner string `json:"nameWithOwner"`
 	} `json:"repository"`
+	Number           int     `json:"number"`
 	IsDraft          bool    `json:"isDraft"`
 	ReviewDecision   *string `json:"reviewDecision"`
 	MergeStateStatus *string `json:"mergeStateStatus"`
@@ -78,11 +85,19 @@ func SetPullRequestService(service PullRequestService) {
 }
 
 func GetPullRequestStates(repos []domain.Repository) map[string]domain.PullRequestState {
-	return pullRequestService.GetPullRequestStates(repos)
+	return pullRequestService.GetPullRequestSync(repos).States
 }
 
-func (GhPullRequestService) GetPullRequestStates(repos []domain.Repository) map[string]domain.PullRequestState {
+func GetPullRequestSync(repos []domain.Repository) PullRequestSync {
+	return pullRequestService.GetPullRequestSync(repos)
+}
+
+func (GhPullRequestService) GetPullRequestSync(repos []domain.Repository) PullRequestSync {
 	states := make(map[string]domain.PullRequestState, len(repos))
+	result := PullRequestSync{
+		States:  states,
+		Tracked: nil,
+	}
 
 	githubByPath, ownerRepos := collectGitHubRepos(repos)
 	for _, repo := range repos {
@@ -94,17 +109,19 @@ func (GhPullRequestService) GetPullRequestStates(repos []domain.Repository) map[
 	}
 
 	if len(ownerRepos) == 0 {
-		return states
+		return result
 	}
 
 	openCounts, err := queryOpenPullRequestCounts(ownerRepos)
 	if err != nil {
-		return markGitHubReposError(states, githubByPath, err)
+		result.States = markGitHubReposError(states, githubByPath, err)
+		return result
 	}
 
-	mySummaries, err := queryMyPullRequestSummaries(ownerRepos)
+	tracked, mySummaries, err := queryMyPullRequests(ownerRepos)
 	if err != nil {
-		return markGitHubReposError(states, githubByPath, err)
+		result.States = markGitHubReposError(states, githubByPath, err)
+		return result
 	}
 
 	for path, ownerRepo := range githubByPath {
@@ -120,7 +137,8 @@ func (GhPullRequestService) GetPullRequestStates(repos []domain.Repository) map[
 		states[path] = state
 	}
 
-	return states
+	result.Tracked = tracked
+	return result
 }
 
 func collectGitHubRepos(repos []domain.Repository) (map[string]string, []string) {
@@ -176,6 +194,19 @@ func parseGitHubRemote(remoteURL string) (owner string, repo string, ok bool) {
 	return parts[0], parts[1], true
 }
 
+func parseNameWithOwner(nameWithOwner string) (owner string, repo string, ok bool) {
+	if strings.TrimSpace(nameWithOwner) == "" {
+		return "", "", false
+	}
+
+	parts := strings.Split(nameWithOwner, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}
+
 func queryOpenPullRequestCounts(ownerRepos []string) (map[string]int, error) {
 	args := []string{"search", "prs", "--state", "open", "--limit", "100", "--json", "repository"}
 	for _, ownerRepo := range ownerRepos {
@@ -205,7 +236,7 @@ func queryOpenPullRequestCounts(ownerRepos []string) (map[string]int, error) {
 	return counts, nil
 }
 
-func queryMyPullRequestSummaries(ownerRepos []string) (map[string]myPullRequestSummary, error) {
+func queryMyPullRequests(ownerRepos []string) ([]pullrequests.Snapshot, map[string]myPullRequestSummary, error) {
 	queryText := "is:pr is:open author:@me " + strings.Join(prefixRepoQualifiers(ownerRepos), " ")
 
 	query := `
@@ -216,6 +247,7 @@ query($q: String!) {
         repository {
           nameWithOwner
         }
+        number
         isDraft
         reviewDecision
         mergeStateStatus
@@ -254,30 +286,42 @@ query($q: String!) {
 
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, normalizeGhError(err)
+		return nil, nil, normalizeGhError(err)
 	}
 
 	var response gqlSearchResponse
 	if err := json.Unmarshal(output, &response); err != nil {
-		return nil, fmt.Errorf("failed to parse gh my-pr response: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse gh my-pr response: %w", err)
 	}
 
+	tracked := make([]pullrequests.Snapshot, 0, len(response.Data.Search.Nodes))
 	summaries := make(map[string]myPullRequestSummary)
 	for _, row := range response.Data.Search.Nodes {
 		ownerRepo := row.Repository.NameWithOwner
-		if ownerRepo == "" {
+		owner, repo, ok := parseNameWithOwner(ownerRepo)
+		if !ok || row.Number <= 0 {
 			continue
 		}
+
+		classification := classifyMyPullRequest(row)
+		tracked = append(tracked, pullrequests.Snapshot{
+			Key: pullrequests.Key{
+				Owner:  owner,
+				Repo:   repo,
+				Number: row.Number,
+			},
+			Status: classification,
+		})
 
 		summary := summaries[ownerRepo]
 		summary.MyOpen++
 
-		switch classifyMyPullRequest(row) {
-		case "ready":
+		switch classification {
+		case pullrequests.StatusReady:
 			summary.MyReady++
-		case "blocked":
+		case pullrequests.StatusBlocked:
 			summary.MyBlocked++
-		case "review":
+		case pullrequests.StatusReview:
 			summary.MyReview++
 		default:
 			summary.MyChecks++
@@ -286,17 +330,21 @@ query($q: String!) {
 		summaries[ownerRepo] = summary
 	}
 
-	return summaries, nil
+	sort.Slice(tracked, func(i, j int) bool {
+		return tracked[i].Key.String() < tracked[j].Key.String()
+	})
+
+	return tracked, summaries, nil
 }
 
-func classifyMyPullRequest(row gqlPullRequestNode) string {
+func classifyMyPullRequest(row gqlPullRequestNode) pullrequests.Status {
 	if row.IsDraft {
-		return "blocked"
+		return pullrequests.StatusBlocked
 	}
 
 	mergeState := strings.ToUpper(strings.TrimSpace(derefString(row.MergeStateStatus)))
 	if mergeState == "DIRTY" || mergeState == "CONFLICTING" || mergeState == "BLOCKED" || mergeState == "UNKNOWN" {
-		return "blocked"
+		return pullrequests.StatusBlocked
 	}
 	mergeStateUnstable := mergeState == "UNSTABLE"
 
@@ -339,36 +387,36 @@ func classifyMyPullRequest(row gqlPullRequestNode) string {
 	}
 
 	if hasFailingChecks {
-		return "blocked"
+		return pullrequests.StatusBlocked
 	}
 
 	review := strings.ToUpper(strings.TrimSpace(derefString(row.ReviewDecision)))
 	if review == "CHANGES_REQUESTED" {
-		return "blocked"
+		return pullrequests.StatusBlocked
 	}
 
 	if hasChecks && hasPendingChecks {
-		return "checks"
+		return pullrequests.StatusChecks
 	}
 
 	if review == "APPROVED" {
-		return "ready"
+		return pullrequests.StatusReady
 	}
 
 	if review == "REVIEW_REQUIRED" {
-		return "review"
+		return pullrequests.StatusReview
 	}
 
 	if review == "" {
 		// GitHub can return a nil reviewDecision when no approving review is required.
 		// If checks are clear and merge state is otherwise healthy, treat as ready.
 		if mergeStateUnstable {
-			return "checks"
+			return pullrequests.StatusChecks
 		}
-		return "ready"
+		return pullrequests.StatusReady
 	}
 
-	return "review"
+	return pullrequests.StatusReview
 }
 
 func latestStatusCheckRollup(row gqlPullRequestNode) *gqlStatusCheckRollup {

--- a/internal/git/pull_requests_test.go
+++ b/internal/git/pull_requests_test.go
@@ -1,6 +1,9 @@
 package git
 
-import "testing"
+import (
+	"fresh/internal/pullrequests"
+	"testing"
+)
 
 func strPtr(s string) *string {
 	return &s
@@ -54,7 +57,7 @@ func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
 	tests := []struct {
 		name string
 		node gqlPullRequestNode
-		want string
+		want pullrequests.Status
 	}{
 		{
 			name: "draft is blocked",
@@ -62,42 +65,42 @@ func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
 				withDraft(),
 				withReviewDecision("APPROVED"),
 			),
-			want: "blocked",
+			want: pullrequests.StatusBlocked,
 		},
 		{
 			name: "merge blocked is blocked",
 			node: makePRNode(
 				withMergeState("BLOCKED"),
 			),
-			want: "blocked",
+			want: pullrequests.StatusBlocked,
 		},
 		{
 			name: "failing checks are blocked",
 			node: makePRNode(
 				withRollup(gqlStatusCheckRollup{State: "FAILURE"}),
 			),
-			want: "blocked",
+			want: pullrequests.StatusBlocked,
 		},
 		{
 			name: "changes requested is blocked",
 			node: makePRNode(
 				withReviewDecision("CHANGES_REQUESTED"),
 			),
-			want: "blocked",
+			want: pullrequests.StatusBlocked,
 		},
 		{
 			name: "pending checks is checks",
 			node: makePRNode(
 				withRollup(gqlStatusCheckRollup{State: "PENDING"}),
 			),
-			want: "checks",
+			want: pullrequests.StatusChecks,
 		},
 		{
 			name: "approved with no pending checks is ready",
 			node: makePRNode(
 				withReviewDecision("APPROVED"),
 			),
-			want: "ready",
+			want: pullrequests.StatusReady,
 		},
 		{
 			name: "review required remains review",
@@ -105,21 +108,26 @@ func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
 				withReviewDecision("REVIEW_REQUIRED"),
 				withMergeState("CLEAN"),
 			),
-			want: "review",
+			want: pullrequests.StatusReview,
 		},
 		{
 			name: "no review required and clean merge is ready",
 			node: makePRNode(
 				withMergeState("CLEAN"),
 			),
-			want: "ready",
+			want: pullrequests.StatusReady,
 		},
 		{
 			name: "unstable merge without rollup details stays checks",
 			node: makePRNode(
 				withMergeState("UNSTABLE"),
 			),
-			want: "checks",
+			want: pullrequests.StatusChecks,
+		},
+		{
+			name: "default requires review",
+			node: makePRNode(),
+			want: pullrequests.StatusReview,
 		},
 	}
 
@@ -149,8 +157,8 @@ func TestClassifyMyPullRequest_ContextDrivenPendingChecks(t *testing.T) {
 	)
 
 	got := classifyMyPullRequest(node)
-	if got != "checks" {
-		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, "checks")
+	if got != pullrequests.StatusChecks {
+		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, pullrequests.StatusChecks)
 	}
 }
 
@@ -169,7 +177,7 @@ func TestClassifyMyPullRequest_ContextDrivenFailingChecks(t *testing.T) {
 	)
 
 	got := classifyMyPullRequest(node)
-	if got != "blocked" {
-		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, "blocked")
+	if got != pullrequests.StatusBlocked {
+		t.Fatalf("classifyMyPullRequest() = %q, want %q", got, pullrequests.StatusBlocked)
 	}
 }

--- a/internal/git/pull_requests_test.go
+++ b/internal/git/pull_requests_test.go
@@ -125,9 +125,9 @@ func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
 			want: pullrequests.StatusChecks,
 		},
 		{
-			name: "default requires review",
+			name: "default with no review decision is ready",
 			node: makePRNode(),
-			want: pullrequests.StatusReview,
+			want: pullrequests.StatusReady,
 		},
 	}
 

--- a/internal/pullrequests/coordinator.go
+++ b/internal/pullrequests/coordinator.go
@@ -1,0 +1,64 @@
+package pullrequests
+
+import (
+	"fmt"
+	"fresh/internal/notifications"
+)
+
+type NotificationSink interface {
+	Upsert(notification notifications.Notification)
+	Resolve(key notifications.PRKey)
+}
+
+type NotificationCoordinator struct {
+	watchlist *Watchlist
+}
+
+func NewNotificationCoordinator(watchlist *Watchlist) *NotificationCoordinator {
+	if watchlist == nil {
+		watchlist = NewWatchlist()
+	}
+
+	return &NotificationCoordinator{
+		watchlist: watchlist,
+	}
+}
+
+func (c *NotificationCoordinator) Sync(tracked []Snapshot, options ApplyOptions, sink NotificationSink) []Change {
+	if c == nil || c.watchlist == nil {
+		return nil
+	}
+
+	changes := c.watchlist.Apply(tracked, options)
+	if sink == nil || len(changes) == 0 {
+		return changes
+	}
+
+	for _, change := range changes {
+		key := notifications.PRKey{
+			Owner:  change.Key.Owner,
+			Repo:   change.Key.Repo,
+			Number: change.Key.Number,
+		}
+
+		switch change.Kind {
+		case ChangeBecameBlocked:
+			sink.Upsert(notifications.Notification{
+				Key:    key,
+				Kind:   notifications.KindBlocked,
+				Reason: fmt.Sprintf("%s is blocked", change.Key.String()),
+			})
+		case ChangeBecameUnblocked:
+			sink.Resolve(key)
+			sink.Upsert(notifications.Notification{
+				Key:    key,
+				Kind:   notifications.KindProgress,
+				Reason: fmt.Sprintf("%s is no longer blocked", change.Key.String()),
+			})
+		case ChangeBlockedRemoved:
+			sink.Resolve(key)
+		}
+	}
+
+	return changes
+}

--- a/internal/pullrequests/coordinator_test.go
+++ b/internal/pullrequests/coordinator_test.go
@@ -1,0 +1,110 @@
+package pullrequests
+
+import (
+	"fresh/internal/notifications"
+	"testing"
+)
+
+type fakeNotificationSink struct {
+	upserts  []notifications.Notification
+	resolves []notifications.PRKey
+}
+
+func (f *fakeNotificationSink) Upsert(notification notifications.Notification) {
+	f.upserts = append(f.upserts, notification)
+}
+
+func (f *fakeNotificationSink) Resolve(key notifications.PRKey) {
+	f.resolves = append(f.resolves, key)
+}
+
+func TestNotificationCoordinator_SeedSuppressesNotifications(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNotificationCoordinator(nil)
+	sink := &fakeNotificationSink{}
+
+	changes := coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: true}, sink)
+
+	if len(changes) != 0 {
+		t.Fatalf("changes = %d, want 0", len(changes))
+	}
+	if len(sink.upserts) != 0 || len(sink.resolves) != 0 {
+		t.Fatalf("notifications sent on seed: upserts=%d resolves=%d", len(sink.upserts), len(sink.resolves))
+	}
+}
+
+func TestNotificationCoordinator_BlockedTransitionUpsertsBlocked(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNotificationCoordinator(nil)
+	_ = coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusReview},
+	}, ApplyOptions{Seed: true}, nil)
+
+	sink := &fakeNotificationSink{}
+	changes := coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{}, sink)
+
+	if len(changes) != 1 || changes[0].Kind != ChangeBecameBlocked {
+		t.Fatalf("changes = %+v, want one %q", changes, ChangeBecameBlocked)
+	}
+	if len(sink.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(sink.upserts))
+	}
+	if sink.upserts[0].Kind != notifications.KindBlocked {
+		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindBlocked)
+	}
+}
+
+func TestNotificationCoordinator_UnblockedTransitionResolvesThenProgress(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNotificationCoordinator(nil)
+	_ = coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: true}, nil)
+
+	sink := &fakeNotificationSink{}
+	changes := coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusChecks},
+	}, ApplyOptions{}, sink)
+
+	if len(changes) != 1 || changes[0].Kind != ChangeBecameUnblocked {
+		t.Fatalf("changes = %+v, want one %q", changes, ChangeBecameUnblocked)
+	}
+	if len(sink.resolves) != 1 {
+		t.Fatalf("resolves = %d, want 1", len(sink.resolves))
+	}
+	if len(sink.upserts) != 1 {
+		t.Fatalf("upserts = %d, want 1", len(sink.upserts))
+	}
+	if sink.upserts[0].Kind != notifications.KindProgress {
+		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindProgress)
+	}
+}
+
+func TestNotificationCoordinator_BlockedRemovedOnlyResolves(t *testing.T) {
+	t.Parallel()
+
+	coordinator := NewNotificationCoordinator(nil)
+	_ = coordinator.Sync([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: true}, nil)
+
+	sink := &fakeNotificationSink{}
+	changes := coordinator.Sync(nil, ApplyOptions{}, sink)
+
+	if len(changes) != 1 || changes[0].Kind != ChangeBlockedRemoved {
+		t.Fatalf("changes = %+v, want one %q", changes, ChangeBlockedRemoved)
+	}
+	if len(sink.resolves) != 1 {
+		t.Fatalf("resolves = %d, want 1", len(sink.resolves))
+	}
+	if len(sink.upserts) != 0 {
+		t.Fatalf("upserts = %d, want 0", len(sink.upserts))
+	}
+}

--- a/internal/pullrequests/watchlist.go
+++ b/internal/pullrequests/watchlist.go
@@ -38,7 +38,7 @@ type ChangeKind string
 const (
 	ChangeBecameBlocked   ChangeKind = "became_blocked"
 	ChangeBecameUnblocked ChangeKind = "became_unblocked"
-	ChangeRemoved         ChangeKind = "removed"
+	ChangeBlockedRemoved  ChangeKind = "blocked_removed"
 )
 
 type Change struct {
@@ -56,12 +56,12 @@ type ApplyOptions struct {
 
 type Watchlist struct {
 	seeded  bool
-	tracked map[string]Snapshot
+	tracked map[Key]Status
 }
 
 func NewWatchlist() *Watchlist {
 	return &Watchlist{
-		tracked: make(map[string]Snapshot),
+		tracked: make(map[Key]Status),
 	}
 }
 
@@ -70,15 +70,15 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 		return nil
 	}
 	if w.tracked == nil {
-		w.tracked = make(map[string]Snapshot)
+		w.tracked = make(map[Key]Status)
 	}
 
-	currentByKey := make(map[string]Snapshot, len(current))
+	currentByKey := make(map[Key]Status, len(current))
 	for _, snapshot := range current {
 		if !snapshot.Key.IsValid() {
 			continue
 		}
-		currentByKey[snapshot.Key.String()] = snapshot
+		currentByKey[snapshot.Key] = snapshot.Status
 	}
 
 	if !w.seeded && options.Seed {
@@ -90,45 +90,48 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 	emitNewBlocked := w.seeded || !options.Seed
 	changes := make([]Change, 0)
 
-	for key, snapshot := range currentByKey {
-		previous, existed := w.tracked[key]
+	for key, currentStatus := range currentByKey {
+		previousStatus, existed := w.tracked[key]
 		switch {
 		case !existed:
-			if emitNewBlocked && snapshot.Status == StatusBlocked {
+			if emitNewBlocked && currentStatus == StatusBlocked {
 				changes = append(changes, Change{
 					Kind:    ChangeBecameBlocked,
-					Key:     snapshot.Key,
-					Current: snapshot.Status,
+					Key:     key,
+					Current: currentStatus,
 				})
 			}
-		case previous.Status != snapshot.Status:
+		case previousStatus != currentStatus:
 			switch {
-			case snapshot.Status == StatusBlocked:
+			case currentStatus == StatusBlocked:
 				changes = append(changes, Change{
 					Kind:     ChangeBecameBlocked,
-					Key:      snapshot.Key,
-					Previous: previous.Status,
-					Current:  snapshot.Status,
+					Key:      key,
+					Previous: previousStatus,
+					Current:  currentStatus,
 				})
-			case previous.Status == StatusBlocked:
+			case previousStatus == StatusBlocked:
 				changes = append(changes, Change{
 					Kind:     ChangeBecameUnblocked,
-					Key:      snapshot.Key,
-					Previous: previous.Status,
-					Current:  snapshot.Status,
+					Key:      key,
+					Previous: previousStatus,
+					Current:  currentStatus,
 				})
 			}
 		}
 	}
 
-	for key, previous := range w.tracked {
+	for key, previousStatus := range w.tracked {
 		if _, ok := currentByKey[key]; ok {
 			continue
 		}
+		if previousStatus != StatusBlocked {
+			continue
+		}
 		changes = append(changes, Change{
-			Kind:     ChangeRemoved,
-			Key:      previous.Key,
-			Previous: previous.Status,
+			Kind:     ChangeBlockedRemoved,
+			Key:      key,
+			Previous: previousStatus,
 		})
 	}
 
@@ -136,13 +139,21 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 	w.seeded = true
 
 	sort.Slice(changes, func(i, j int) bool {
-		left := changes[i].Key.String()
-		right := changes[j].Key.String()
-		if left == right {
+		if changes[i].Key == changes[j].Key {
 			return changes[i].Kind < changes[j].Kind
 		}
-		return left < right
+		return keyLess(changes[i].Key, changes[j].Key)
 	})
 
 	return changes
+}
+
+func keyLess(left, right Key) bool {
+	if left.Owner != right.Owner {
+		return left.Owner < right.Owner
+	}
+	if left.Repo != right.Repo {
+		return left.Repo < right.Repo
+	}
+	return left.Number < right.Number
 }

--- a/internal/pullrequests/watchlist.go
+++ b/internal/pullrequests/watchlist.go
@@ -1,0 +1,148 @@
+package pullrequests
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Status string
+
+const (
+	StatusReady   Status = "ready"
+	StatusBlocked Status = "blocked"
+	StatusReview  Status = "review"
+	StatusChecks  Status = "checks"
+)
+
+type Key struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+func (k Key) String() string {
+	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Repo, k.Number)
+}
+
+func (k Key) IsValid() bool {
+	return k.Owner != "" && k.Repo != "" && k.Number > 0
+}
+
+type Snapshot struct {
+	Key    Key
+	Status Status
+}
+
+type ChangeKind string
+
+const (
+	ChangeBecameBlocked   ChangeKind = "became_blocked"
+	ChangeBecameUnblocked ChangeKind = "became_unblocked"
+	ChangeRemoved         ChangeKind = "removed"
+)
+
+type Change struct {
+	Kind     ChangeKind
+	Key      Key
+	Previous Status
+	Current  Status
+}
+
+type ApplyOptions struct {
+	// Seed suppresses change events the first time Apply is called, so the
+	// initial sync becomes a baseline instead of generating alerts.
+	Seed bool
+}
+
+type Watchlist struct {
+	seeded  bool
+	tracked map[string]Snapshot
+}
+
+func NewWatchlist() *Watchlist {
+	return &Watchlist{
+		tracked: make(map[string]Snapshot),
+	}
+}
+
+func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
+	if w == nil {
+		return nil
+	}
+	if w.tracked == nil {
+		w.tracked = make(map[string]Snapshot)
+	}
+
+	currentByKey := make(map[string]Snapshot, len(current))
+	for _, snapshot := range current {
+		if !snapshot.Key.IsValid() {
+			continue
+		}
+		currentByKey[snapshot.Key.String()] = snapshot
+	}
+
+	if !w.seeded && options.Seed {
+		w.tracked = currentByKey
+		w.seeded = true
+		return nil
+	}
+
+	emitNewBlocked := w.seeded || !options.Seed
+	changes := make([]Change, 0)
+
+	for key, snapshot := range currentByKey {
+		previous, existed := w.tracked[key]
+		switch {
+		case !existed:
+			if emitNewBlocked && snapshot.Status == StatusBlocked {
+				changes = append(changes, Change{
+					Kind:    ChangeBecameBlocked,
+					Key:     snapshot.Key,
+					Current: snapshot.Status,
+				})
+			}
+		case previous.Status != snapshot.Status:
+			switch {
+			case snapshot.Status == StatusBlocked:
+				changes = append(changes, Change{
+					Kind:     ChangeBecameBlocked,
+					Key:      snapshot.Key,
+					Previous: previous.Status,
+					Current:  snapshot.Status,
+				})
+			case previous.Status == StatusBlocked:
+				changes = append(changes, Change{
+					Kind:     ChangeBecameUnblocked,
+					Key:      snapshot.Key,
+					Previous: previous.Status,
+					Current:  snapshot.Status,
+				})
+			}
+		}
+	}
+
+	for key, previous := range w.tracked {
+		if _, ok := currentByKey[key]; ok {
+			continue
+		}
+		changes = append(changes, Change{
+			Kind:     ChangeRemoved,
+			Key:      previous.Key,
+			Previous: previous.Status,
+		})
+	}
+
+	w.tracked = currentByKey
+	w.seeded = true
+
+	sort.Slice(changes, func(i, j int) bool {
+		left := changes[i].Key.String()
+		right := changes[j].Key.String()
+		if left == right {
+			return changes[i].Kind < changes[j].Kind
+		}
+		return left < right
+	})
+
+	return changes
+}

--- a/internal/pullrequests/watchlist_test.go
+++ b/internal/pullrequests/watchlist_test.go
@@ -1,0 +1,153 @@
+package pullrequests
+
+import "testing"
+
+func TestWatchlist_SeedInitialSnapshotWithoutAlerts(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+		{Key: Key{Owner: "acme", Repo: "web", Number: 44}, Status: StatusReview},
+	}, ApplyOptions{Seed: true})
+
+	if len(changes) != 0 {
+		t.Fatalf("changes = %d, want 0", len(changes))
+	}
+}
+
+func TestWatchlist_NoAlertWhenBlockedStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{})
+
+	if len(changes) != 0 {
+		t.Fatalf("changes = %d, want 0", len(changes))
+	}
+}
+
+func TestWatchlist_EmitsBlockedTransition(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusReview},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeBecameBlocked {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBecameBlocked)
+	}
+}
+
+func TestWatchlist_EmitsUnblockedTransition(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusChecks},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeBecameUnblocked {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBecameUnblocked)
+	}
+}
+
+func TestWatchlist_RemovesTerminalPullRequests(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+		{Key: Key{Owner: "acme", Repo: "web", Number: 44}, Status: StatusReview},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "web", Number: 44}, Status: StatusReview},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeRemoved {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeRemoved)
+	}
+	if changes[0].Key.Number != 12 {
+		t.Fatalf("number = %d, want 12", changes[0].Key.Number)
+	}
+}
+
+func TestWatchlist_NewBlockedAfterSeedEmitsAlert(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "web", Number: 44}, Status: StatusReview},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "web", Number: 44}, Status: StatusReview},
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeBecameBlocked {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBecameBlocked)
+	}
+	if changes[0].Key.Number != 12 {
+		t.Fatalf("number = %d, want 12", changes[0].Key.Number)
+	}
+}
+
+func TestWatchlist_FirstApplyWithoutSeedStillAlertsBlocked(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: false})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeBecameBlocked {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBecameBlocked)
+	}
+}
+
+func TestWatchlist_IgnoresInvalidKeys(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	changes := watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "", Repo: "api", Number: 12}, Status: StatusBlocked},
+		{Key: Key{Owner: "acme", Repo: "", Number: 12}, Status: StatusBlocked},
+		{Key: Key{Owner: "acme", Repo: "api", Number: 0}, Status: StatusBlocked},
+	}, ApplyOptions{Seed: false})
+
+	if len(changes) != 0 {
+		t.Fatalf("changes = %d, want 0", len(changes))
+	}
+}

--- a/internal/pullrequests/watchlist_test.go
+++ b/internal/pullrequests/watchlist_test.go
@@ -73,7 +73,7 @@ func TestWatchlist_EmitsUnblockedTransition(t *testing.T) {
 	}
 }
 
-func TestWatchlist_RemovesTerminalPullRequests(t *testing.T) {
+func TestWatchlist_EmitsBlockedRemovedForTerminalBlockedPullRequest(t *testing.T) {
 	t.Parallel()
 
 	watchlist := NewWatchlist()
@@ -89,11 +89,25 @@ func TestWatchlist_RemovesTerminalPullRequests(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("changes = %d, want 1", len(changes))
 	}
-	if changes[0].Kind != ChangeRemoved {
-		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeRemoved)
+	if changes[0].Kind != ChangeBlockedRemoved {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBlockedRemoved)
 	}
 	if changes[0].Key.Number != 12 {
 		t.Fatalf("number = %d, want 12", changes[0].Key.Number)
+	}
+}
+
+func TestWatchlist_DoesNotEmitRemovalForNonBlockedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusReview},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply(nil, ApplyOptions{})
+	if len(changes) != 0 {
+		t.Fatalf("changes = %d, want 0", len(changes))
 	}
 }
 

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -140,8 +140,12 @@ func performPullRequestSync(repos []domain.Repository, trigger PullRequestSyncTr
 	snapshot := append([]domain.Repository(nil), repos...)
 
 	return func() tea.Msg {
-		states := git.GetPullRequestStates(snapshot)
-		return PullRequestStatesUpdatedMsg{States: states, Trigger: trigger}
+		sync := git.GetPullRequestSync(snapshot)
+		return PullRequestStatesUpdatedMsg{
+			States:  sync.States,
+			Tracked: sync.Tracked,
+			Trigger: trigger,
+		}
 	}
 }
 

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -136,15 +136,16 @@ func listenForPruneProgress(state pruneWorkState) tea.Cmd {
 	}
 }
 
-func performPullRequestSync(repos []domain.Repository, trigger PullRequestSyncTrigger) tea.Cmd {
+func performPullRequestSync(repos []domain.Repository, trigger PullRequestSyncTrigger, generation uint64) tea.Cmd {
 	snapshot := append([]domain.Repository(nil), repos...)
 
 	return func() tea.Msg {
 		sync := git.GetPullRequestSync(snapshot)
 		return PullRequestStatesUpdatedMsg{
-			States:  sync.States,
-			Tracked: sync.Tracked,
-			Trigger: trigger,
+			Generation: generation,
+			States:     sync.States,
+			Tracked:    sync.Tracked,
+			Trigger:    trigger,
 		}
 	}
 }

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -1,7 +1,6 @@
 package listing
 
 import (
-	"fmt"
 	"fresh/internal/domain"
 	"fresh/internal/notifications"
 	"fresh/internal/pullrequests"
@@ -59,28 +58,29 @@ func newListKeyMap() *listKeyMap {
 }
 
 type Model struct {
-	Repositories   []domain.Repository
-	Cursor         int
-	Keys           *listKeyMap
-	layout         ColumnLayout
-	width, height  int
-	ShowLegend     bool
-	InfoPhase      uint64
-	RotateEvery    time.Duration
-	ActivityTTL    time.Duration
-	RecentInfo     map[string][]TimedInfoMessage
-	StartupPRSync  bool
-	PRSyncInFlight int
-	PRSyncSpinner  spinner.Model
-	BlockedSpinner spinner.Model
-	ReadySpinner   spinner.Model
-	WatchEnabled   bool
-	WatchToken     uint64
-	WatchBackoff   int
-	WatchEvery     time.Duration
-	WatchMaxEvery  time.Duration
-	watchlist      *pullrequests.Watchlist
-	notifier       *notifications.Notifier
+	Repositories     []domain.Repository
+	Cursor           int
+	Keys             *listKeyMap
+	layout           ColumnLayout
+	width, height    int
+	ShowLegend       bool
+	InfoPhase        uint64
+	RotateEvery      time.Duration
+	ActivityTTL      time.Duration
+	RecentInfo       map[string][]TimedInfoMessage
+	StartupPRSync    bool
+	PRSyncInFlight   int
+	PRSyncGeneration uint64
+	PRSyncSpinner    spinner.Model
+	BlockedSpinner   spinner.Model
+	ReadySpinner     spinner.Model
+	WatchEnabled     bool
+	WatchToken       uint64
+	WatchBackoff     int
+	WatchEvery       time.Duration
+	WatchMaxEvery    time.Duration
+	prCoordinator    *pullrequests.NotificationCoordinator
+	notifier         *notifications.Notifier
 }
 
 func New(repos []domain.Repository) *Model {
@@ -97,26 +97,27 @@ func NewWithNotifier(repos []domain.Repository, notifier *notifications.Notifier
 	}
 
 	return &Model{
-		Repositories:   repos,
-		Cursor:         0,
-		Keys:           newListKeyMap(),
-		layout:         calculateColumnLayout(repos, 0),
-		ShowLegend:     false,
-		RotateEvery:    10 * time.Second,
-		ActivityTTL:    10 * time.Second,
-		RecentInfo:     make(map[string][]TimedInfoMessage),
-		StartupPRSync:  false,
-		PRSyncInFlight: 0,
-		PRSyncSpinner:  common.NewPullRequestSpinner(),
-		BlockedSpinner: common.NewBlockedPullRequestSpinner(),
-		ReadySpinner:   common.NewReadyPullRequestSpinner(),
-		WatchEnabled:   false,
-		WatchToken:     0,
-		WatchBackoff:   0,
-		WatchEvery:     defaultWatchInterval,
-		WatchMaxEvery:  defaultWatchMaxInterval,
-		watchlist:      pullrequests.NewWatchlist(),
-		notifier:       notifier,
+		Repositories:     repos,
+		Cursor:           0,
+		Keys:             newListKeyMap(),
+		layout:           calculateColumnLayout(repos, 0),
+		ShowLegend:       false,
+		RotateEvery:      10 * time.Second,
+		ActivityTTL:      10 * time.Second,
+		RecentInfo:       make(map[string][]TimedInfoMessage),
+		StartupPRSync:    false,
+		PRSyncInFlight:   0,
+		PRSyncGeneration: 0,
+		PRSyncSpinner:    common.NewPullRequestSpinner(),
+		BlockedSpinner:   common.NewBlockedPullRequestSpinner(),
+		ReadySpinner:     common.NewReadyPullRequestSpinner(),
+		WatchEnabled:     false,
+		WatchToken:       0,
+		WatchBackoff:     0,
+		WatchEvery:       defaultWatchInterval,
+		WatchMaxEvery:    defaultWatchMaxInterval,
+		prCoordinator:    pullrequests.NewNotificationCoordinator(nil),
+		notifier:         notifier,
 	}
 }
 
@@ -230,6 +231,14 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		}
 
 	case PullRequestStatesUpdatedMsg:
+		if msg.Generation != m.PRSyncGeneration {
+			m.completePullRequestSync()
+			if msg.Trigger == pullRequestSyncWatch && m.WatchEnabled {
+				return m, scheduleWatchTick(m.currentWatchInterval(), m.WatchToken)
+			}
+			return m, nil
+		}
+
 		m.applyPullRequestStates(msg.States)
 		syncFailed := hasPullRequestSyncError(msg.States)
 		if !syncFailed {
@@ -374,40 +383,11 @@ func (m *Model) applyPullRequestStates(states map[string]domain.PullRequestState
 }
 
 func (m *Model) applyPullRequestWatchlist(tracked []pullrequests.Snapshot, seed bool) {
-	if m.watchlist == nil {
+	if m.prCoordinator == nil {
 		return
 	}
 
-	changes := m.watchlist.Apply(tracked, pullrequests.ApplyOptions{Seed: seed})
-	if len(changes) == 0 || m.notifier == nil {
-		return
-	}
-
-	for _, change := range changes {
-		notificationKey := notifications.PRKey{
-			Owner:  change.Key.Owner,
-			Repo:   change.Key.Repo,
-			Number: change.Key.Number,
-		}
-
-		switch change.Kind {
-		case pullrequests.ChangeBecameBlocked:
-			m.notifier.Upsert(notifications.Notification{
-				Key:    notificationKey,
-				Kind:   notifications.KindBlocked,
-				Reason: fmt.Sprintf("%s is blocked", change.Key.String()),
-			})
-		case pullrequests.ChangeBecameUnblocked:
-			m.notifier.Resolve(notificationKey)
-			m.notifier.Upsert(notifications.Notification{
-				Key:    notificationKey,
-				Kind:   notifications.KindProgress,
-				Reason: fmt.Sprintf("%s is no longer blocked", change.Key.String()),
-			})
-		case pullrequests.ChangeRemoved:
-			m.notifier.Resolve(notificationKey)
-		}
-	}
+	m.prCoordinator.Sync(tracked, pullrequests.ApplyOptions{Seed: seed}, m.notifier)
 }
 
 func (m *Model) View() string {

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -1,8 +1,10 @@
 package listing
 
 import (
+	"fmt"
 	"fresh/internal/domain"
 	"fresh/internal/notifications"
+	"fresh/internal/pullrequests"
 	"fresh/internal/ui/views/common"
 	"sort"
 	"strings"
@@ -77,6 +79,7 @@ type Model struct {
 	WatchBackoff   int
 	WatchEvery     time.Duration
 	WatchMaxEvery  time.Duration
+	watchlist      *pullrequests.Watchlist
 	notifier       *notifications.Notifier
 }
 
@@ -112,6 +115,7 @@ func NewWithNotifier(repos []domain.Repository, notifier *notifications.Notifier
 		WatchBackoff:   0,
 		WatchEvery:     defaultWatchInterval,
 		WatchMaxEvery:  defaultWatchMaxInterval,
+		watchlist:      pullrequests.NewWatchlist(),
 		notifier:       notifier,
 	}
 }
@@ -227,9 +231,13 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 
 	case PullRequestStatesUpdatedMsg:
 		m.applyPullRequestStates(msg.States)
+		syncFailed := hasPullRequestSyncError(msg.States)
+		if !syncFailed {
+			m.applyPullRequestWatchlist(msg.Tracked, msg.Trigger == pullRequestSyncStartup)
+		}
 		m.completePullRequestSync()
 		if msg.Trigger == pullRequestSyncWatch && m.WatchEnabled {
-			m.updateWatchBackoff(hasPullRequestSyncError(msg.States))
+			m.updateWatchBackoff(syncFailed)
 			return m, scheduleWatchTick(m.currentWatchInterval(), m.WatchToken)
 		}
 
@@ -361,6 +369,43 @@ func (m *Model) applyPullRequestStates(states map[string]domain.PullRequestState
 		repo := &m.Repositories[i]
 		if state, ok := states[repo.Path]; ok {
 			repo.PullRequests = state
+		}
+	}
+}
+
+func (m *Model) applyPullRequestWatchlist(tracked []pullrequests.Snapshot, seed bool) {
+	if m.watchlist == nil {
+		return
+	}
+
+	changes := m.watchlist.Apply(tracked, pullrequests.ApplyOptions{Seed: seed})
+	if len(changes) == 0 || m.notifier == nil {
+		return
+	}
+
+	for _, change := range changes {
+		notificationKey := notifications.PRKey{
+			Owner:  change.Key.Owner,
+			Repo:   change.Key.Repo,
+			Number: change.Key.Number,
+		}
+
+		switch change.Kind {
+		case pullrequests.ChangeBecameBlocked:
+			m.notifier.Upsert(notifications.Notification{
+				Key:    notificationKey,
+				Kind:   notifications.KindBlocked,
+				Reason: fmt.Sprintf("%s is blocked", change.Key.String()),
+			})
+		case pullrequests.ChangeBecameUnblocked:
+			m.notifier.Resolve(notificationKey)
+			m.notifier.Upsert(notifications.Notification{
+				Key:    notificationKey,
+				Kind:   notifications.KindProgress,
+				Reason: fmt.Sprintf("%s is no longer blocked", change.Key.String()),
+			})
+		case pullrequests.ChangeRemoved:
+			m.notifier.Resolve(notificationKey)
 		}
 	}
 }

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -23,9 +23,10 @@ const (
 )
 
 type PullRequestStatesUpdatedMsg struct {
-	States  map[string]domain.PullRequestState
-	Tracked []pullrequests.Snapshot
-	Trigger PullRequestSyncTrigger
+	Generation uint64
+	States     map[string]domain.PullRequestState
+	Tracked    []pullrequests.Snapshot
+	Trigger    PullRequestSyncTrigger
 }
 
 type OpenPullRequestsMsg struct {

--- a/internal/ui/views/listing/messages.go
+++ b/internal/ui/views/listing/messages.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"fresh/internal/domain"
+	"fresh/internal/pullrequests"
 
 	tea "charm.land/bubbletea/v2"
 )
@@ -23,6 +24,7 @@ const (
 
 type PullRequestStatesUpdatedMsg struct {
 	States  map[string]domain.PullRequestState
+	Tracked []pullrequests.Snapshot
 	Trigger PullRequestSyncTrigger
 }
 

--- a/internal/ui/views/listing/pull_request_sync.go
+++ b/internal/ui/views/listing/pull_request_sync.go
@@ -4,9 +4,11 @@ import tea "charm.land/bubbletea/v2"
 
 func (m *Model) startPullRequestSync(trigger PullRequestSyncTrigger) tea.Cmd {
 	m.PRSyncInFlight++
+	m.PRSyncGeneration++
+	generation := m.PRSyncGeneration
 
 	return tea.Batch(
-		performPullRequestSync(m.Repositories, trigger),
+		performPullRequestSync(m.Repositories, trigger, generation),
 		m.PRSyncSpinner.Tick,
 	)
 }

--- a/internal/ui/views/listing/pull_request_sync_test.go
+++ b/internal/ui/views/listing/pull_request_sync_test.go
@@ -52,12 +52,66 @@ func TestUpdatePullRequestStatesCompletesInFlightSync(t *testing.T) {
 	m := New(nil)
 	_ = m.startPullRequestSync(pullRequestSyncManual)
 
-	newM, _ := m.Update(PullRequestStatesUpdatedMsg{Trigger: pullRequestSyncManual})
+	newM, _ := m.Update(PullRequestStatesUpdatedMsg{
+		Generation: m.PRSyncGeneration,
+		Trigger:    pullRequestSyncManual,
+	})
 	if newM == nil {
 		t.Fatal("expected model")
 	}
 	if m.PRSyncInFlight != 0 {
 		t.Fatalf("PRSyncInFlight = %d, want 0", m.PRSyncInFlight)
+	}
+}
+
+func TestUpdatePullRequestStatesIgnoresStaleGeneration(t *testing.T) {
+	m := New(sampleWatchRepos())
+	_ = m.startPullRequestSync(pullRequestSyncManual)
+	staleGeneration := m.PRSyncGeneration
+	_ = m.startPullRequestSync(pullRequestSyncManual)
+	latestGeneration := m.PRSyncGeneration
+
+	repoPath := m.Repositories[0].Path
+	m.Repositories[0].PullRequests = domain.PullRequestCount{Open: 7}
+
+	newM, cmd := m.Update(PullRequestStatesUpdatedMsg{
+		Generation: staleGeneration,
+		States: map[string]domain.PullRequestState{
+			repoPath: domain.PullRequestCount{Open: 99},
+		},
+		Trigger: pullRequestSyncManual,
+	})
+	if newM == nil {
+		t.Fatal("expected model")
+	}
+	if cmd != nil {
+		t.Fatal("stale manual sync should not schedule work")
+	}
+	if m.PRSyncInFlight != 1 {
+		t.Fatalf("PRSyncInFlight = %d, want 1", m.PRSyncInFlight)
+	}
+
+	state, ok := m.Repositories[0].PullRequests.(domain.PullRequestCount)
+	if !ok {
+		t.Fatalf("pull request state type = %T, want domain.PullRequestCount", m.Repositories[0].PullRequests)
+	}
+	if state.Open != 7 {
+		t.Fatalf("stale sync overwrote state: Open = %d, want 7", state.Open)
+	}
+
+	_, _ = m.Update(PullRequestStatesUpdatedMsg{
+		Generation: latestGeneration,
+		States: map[string]domain.PullRequestState{
+			repoPath: domain.PullRequestCount{Open: 5},
+		},
+		Trigger: pullRequestSyncManual,
+	})
+	state, ok = m.Repositories[0].PullRequests.(domain.PullRequestCount)
+	if !ok {
+		t.Fatalf("pull request state type = %T, want domain.PullRequestCount", m.Repositories[0].PullRequests)
+	}
+	if state.Open != 5 {
+		t.Fatalf("latest sync not applied: Open = %d, want 5", state.Open)
 	}
 }
 

--- a/internal/ui/views/listing/watch_test.go
+++ b/internal/ui/views/listing/watch_test.go
@@ -204,3 +204,29 @@ func TestPullRequestWatchSuccessResetsBackoff(t *testing.T) {
 		t.Fatalf("currentWatchInterval() = %s, want %s", got, time.Minute)
 	}
 }
+
+func TestStaleWatchSyncStillReschedulesTick(t *testing.T) {
+	m := New(nil)
+	_ = m.toggleWatchMode()
+	m.WatchBackoff = 2
+	m.PRSyncGeneration = 3
+
+	newM, cmd := m.Update(PullRequestStatesUpdatedMsg{
+		Generation: 2, // stale
+		States: map[string]domain.PullRequestState{
+			"/repo/a": domain.PullRequestError{Message: "gh: timeout"},
+		},
+		Trigger: pullRequestSyncWatch,
+	})
+
+	if newM == nil {
+		t.Fatal("expected updated model")
+	}
+	if cmd == nil {
+		t.Fatal("expected watch reschedule command from stale watch response")
+	}
+	// Stale responses should not modify backoff state.
+	if m.WatchBackoff != 2 {
+		t.Fatalf("WatchBackoff = %d, want 2", m.WatchBackoff)
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated `internal/pullrequests` watchlist to track per-PR status across syncs
- extend GH PR sync to return both per-repo summary state and per-PR tracked snapshots (`owner/repo/number + status`)
- seed watchlist on startup sync (no initial alerts), then only notify on transitions during manual/watch syncs
- resolve tracked notifications when PRs leave the open set (closed/merged)
- skip watchlist updates when GH sync errors occur so transient failures do not clear tracked state

## Testing
- `mise exec -- go test ./...`
