### PR TITLE
tests: trim low-value UI framework assertions

### DIFF
--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"fresh/internal/domain"
-	"fresh/internal/ui/views/listing"
 	"fresh/internal/ui/views/scanning"
 	"testing"
 
@@ -118,37 +117,6 @@ func TestMainModel_DelegatesKeyMsgToListingInRepoListView(t *testing.T) {
 	}
 }
 
-func TestMainModel_ViewInScanningMode(t *testing.T) {
-	t.Parallel()
-
-	m := New(t.TempDir())
-	output := m.View()
-
-	// Scanning view should contain scanning-related content
-	if output.Content == "" {
-		t.Error("expected non-empty view output in scanning mode")
-	}
-}
-
-func TestMainModel_ViewInListingMode(t *testing.T) {
-	t.Parallel()
-
-	m := New(t.TempDir())
-
-	repos := []domain.Repository{
-		{Name: "test-repo", Path: "/tmp/test-repo", Activity: domain.IdleActivity{}, LocalState: domain.CleanLocalState{}, RemoteState: domain.Synced{}, Branches: domain.Branches{Current: domain.OnBranch{Name: "main"}}},
-	}
-	m.Update(scanning.ScanFinishedMsg{Repos: repos})
-	m.listingView.Cursor = 0
-	m.listingView.Repositories[0].Activity = &domain.IdleActivity{}
-
-	output := m.View()
-
-	if output.Content == "" {
-		t.Error("expected non-empty view output in listing mode")
-	}
-}
-
 func TestMainModel_ScanFinishedMsg_WithEmptyRepos(t *testing.T) {
 	t.Parallel()
 
@@ -166,21 +134,4 @@ func TestMainModel_ScanFinishedMsg_WithEmptyRepos(t *testing.T) {
 	}
 }
 
-func TestMainModel_DefaultViewReturnsEmpty(t *testing.T) {
-	t.Parallel()
-
-	// Construct a model with an invalid view to test the default case
-	m := &MainModel{
-		currentView: CurrentView(99),
-	}
-
-	output := m.View()
-	if output.Content != "" {
-		t.Errorf("expected empty string for unknown view, got %q", output.Content)
-	}
-}
-
-// Verify that unused imports don't cause issues — these are needed for
-// the test to compile but the linter may flag them without explicit use.
-var _ = listing.New
 var _ = scanning.ScanFinishedMsg{}

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -7,8 +7,6 @@ import (
 
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/common"
-
-	"charm.land/lipgloss/v2"
 )
 
 // ============================================================================
@@ -365,17 +363,6 @@ func TestBuildPullRequestStatus(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func TestBuildPullRequestStatus_MyOpenUsesWhiteMarker(t *testing.T) {
-	t.Parallel()
-
-	got := buildPullRequestStatus(domain.PullRequestCount{Open: 2, MyOpen: 1}, InfoRuntime{})
-	wantMarker := lipgloss.NewStyle().Foreground(common.TextPrimary).Render("(*)")
-
-	if !strings.Contains(got, wantMarker) {
-		t.Fatalf("buildPullRequestStatus() = %q, expected white marker %q", got, wantMarker)
 	}
 }
 

--- a/internal/ui/views/listing/watch_test.go
+++ b/internal/ui/views/listing/watch_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"fresh/internal/domain"
-
-	tea "charm.land/bubbletea/v2"
 )
 
 func TestToggleWatchModeTurnsOnAndSchedulesTick(t *testing.T) {
@@ -132,15 +130,8 @@ func TestUpdateWatchTickStartsWatchRefreshCycle(t *testing.T) {
 	if _, ok := newM.Repositories[0].Activity.(*domain.RefreshingActivity); !ok {
 		t.Fatalf("repo activity = %T, want *domain.RefreshingActivity", newM.Repositories[0].Activity)
 	}
-
-	type batchCommand interface {
-		Cmds() []tea.Cmd
-	}
-	if _, ok := any(cmd).(batchCommand); !ok {
-		// Bubble Tea batch cmd type is unexported; tolerate inability to assert internals.
-		if msg := cmd(); msg == nil {
-			t.Fatal("expected non-nil message from watch refresh command")
-		}
+	if m.PRSyncInFlight != 1 {
+		t.Fatalf("PRSyncInFlight = %d, want 1", m.PRSyncInFlight)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove tests that primarily validated Bubble Tea/Lip Gloss internals instead of app behavior
- keep watch refresh assertions focused on listing model state transitions
- simplify TUI tests by dropping low-signal view rendering checks

## Validation
- mise exec -- go test ./... -count=1