### PR TITLE
Add ready PR pulse alert and improve ready/review classification

### DIFF
--- a/internal/git/pull_requests.go
+++ b/internal/git/pull_requests.go
@@ -298,6 +298,7 @@ func classifyMyPullRequest(row gqlPullRequestNode) string {
 	if mergeState == "DIRTY" || mergeState == "CONFLICTING" || mergeState == "BLOCKED" || mergeState == "UNKNOWN" {
 		return "blocked"
 	}
+	mergeStateUnstable := mergeState == "UNSTABLE"
 
 	hasChecks := false
 	hasFailingChecks := false
@@ -351,6 +352,19 @@ func classifyMyPullRequest(row gqlPullRequestNode) string {
 	}
 
 	if review == "APPROVED" {
+		return "ready"
+	}
+
+	if review == "REVIEW_REQUIRED" {
+		return "review"
+	}
+
+	if review == "" {
+		// GitHub can return a nil reviewDecision when no approving review is required.
+		// If checks are clear and merge state is otherwise healthy, treat as ready.
+		if mergeStateUnstable {
+			return "checks"
+		}
 		return "ready"
 	}
 

--- a/internal/git/pull_requests_test.go
+++ b/internal/git/pull_requests_test.go
@@ -100,9 +100,26 @@ func TestClassifyMyPullRequestDecisionMatrix(t *testing.T) {
 			want: "ready",
 		},
 		{
-			name: "default requires review",
-			node: makePRNode(),
+			name: "review required remains review",
+			node: makePRNode(
+				withReviewDecision("REVIEW_REQUIRED"),
+				withMergeState("CLEAN"),
+			),
 			want: "review",
+		},
+		{
+			name: "no review required and clean merge is ready",
+			node: makePRNode(
+				withMergeState("CLEAN"),
+			),
+			want: "ready",
+		},
+		{
+			name: "unstable merge without rollup details stays checks",
+			node: makePRNode(
+				withMergeState("UNSTABLE"),
+			),
+			want: "checks",
 		},
 	}
 

--- a/internal/ui/views/common/style.go
+++ b/internal/ui/views/common/style.go
@@ -71,6 +71,16 @@ func NewBlockedPullRequestSpinner() spinner.Model {
 	)
 }
 
+func NewReadyPullRequestSpinner() spinner.Model {
+	readySpinner := spinner.Pulse
+	readySpinner.FPS = spinnerFrameInterval
+
+	return spinner.New(
+		spinner.WithSpinner(readySpinner),
+		spinner.WithStyle(lipgloss.NewStyle().Foreground(SubtleGreen).Bold(true)),
+	)
+}
+
 var TableHeaderStyle = lipgloss.NewStyle().
 	Foreground(TextSecondary).
 	Bold(true).
@@ -153,6 +163,10 @@ var PullOutputError = lipgloss.NewStyle().
 
 var AlertSpinnerStyle = lipgloss.NewStyle().
 	Foreground(Red).
+	Bold(true)
+
+var SuccessSpinnerStyle = lipgloss.NewStyle().
+	Foreground(Green).
 	Bold(true)
 
 var PullProgressStyle = lipgloss.NewStyle()

--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -37,6 +37,7 @@ type InfoRuntime struct {
 	PullRequestSyncing   bool
 	PullRequestSpinner   string
 	BlockedSpinner       string
+	ReadySpinner         string
 }
 
 func collectStatusInfoMessages(repo domain.Repository) []InfoMessage {

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -66,6 +66,7 @@ type Model struct {
 	PRSyncInFlight int
 	PRSyncSpinner  spinner.Model
 	BlockedSpinner spinner.Model
+	ReadySpinner   spinner.Model
 	WatchEnabled   bool
 	WatchToken     uint64
 	WatchBackoff   int
@@ -100,6 +101,7 @@ func NewWithNotifier(repos []domain.Repository, notifier *notifications.Notifier
 		PRSyncInFlight: 0,
 		PRSyncSpinner:  common.NewPullRequestSpinner(),
 		BlockedSpinner: common.NewBlockedPullRequestSpinner(),
+		ReadySpinner:   common.NewReadyPullRequestSpinner(),
 		WatchEnabled:   false,
 		WatchToken:     0,
 		WatchBackoff:   0,
@@ -123,6 +125,7 @@ func (m *Model) Init() tea.Cmd {
 		m.StartupPRSync = true
 	}
 	cmds = append(cmds, m.BlockedSpinner.Tick)
+	cmds = append(cmds, m.ReadySpinner.Tick)
 	for i := range m.Repositories {
 		repo := &m.Repositories[i]
 		repo.Activity = &domain.RefreshingActivity{
@@ -304,6 +307,11 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		if blockedCmd != nil {
 			cmds = append(cmds, blockedCmd)
 		}
+		var readyCmd tea.Cmd
+		m.ReadySpinner, readyCmd = m.ReadySpinner.Update(msg)
+		if readyCmd != nil {
+			cmds = append(cmds, readyCmd)
+		}
 		for i := range m.Repositories {
 			switch activity := m.Repositories[i].Activity.(type) {
 			case *domain.RefreshingActivity:
@@ -362,6 +370,7 @@ func (m *Model) View() string {
 		PullRequestSyncing:   m.isPullRequestSyncInFlight(),
 		PullRequestSpinner:   m.pullRequestSpinnerView(),
 		BlockedSpinner:       m.BlockedSpinner.View(),
+		ReadySpinner:         m.ReadySpinner.View(),
 	}
 	s.WriteString(GenerateTable(m.Repositories, m.Cursor, m.layout, runtime))
 	s.WriteString("\n\n")

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -64,7 +64,13 @@ func buildPullRequestAlert(state domain.PullRequestState, runtime InfoRuntime) s
 		Height(1).
 		MaxHeight(1).
 		Align(lipgloss.Left)
-	alertStyle := common.AlertSpinnerStyle.
+	blockedStyle := common.AlertSpinnerStyle.
+		Width(PRAlertWidth).
+		MaxWidth(PRAlertWidth).
+		Height(1).
+		MaxHeight(1).
+		Align(lipgloss.Left)
+	readyStyle := common.SuccessSpinnerStyle.
 		Width(PRAlertWidth).
 		MaxWidth(PRAlertWidth).
 		Height(1).
@@ -72,16 +78,27 @@ func buildPullRequestAlert(state domain.PullRequestState, runtime InfoRuntime) s
 		Align(lipgloss.Left)
 
 	s, ok := state.(domain.PullRequestCount)
-	if !ok || s.MyBlocked <= 0 {
+	if !ok {
 		return baseStyle.Render("")
 	}
 
-	frame := runtime.BlockedSpinner
-	if frame == "" {
-		return alertStyle.Render(common.IconWarning)
+	if s.MyBlocked > 0 {
+		frame := runtime.BlockedSpinner
+		if frame == "" {
+			return blockedStyle.Render(common.IconWarning)
+		}
+		return blockedStyle.Render(frame)
 	}
 
-	return alertStyle.Render(frame)
+	if s.MyReady > 0 {
+		frame := runtime.ReadySpinner
+		if frame == "" {
+			return readyStyle.Render(common.IconClean)
+		}
+		return readyStyle.Render(frame)
+	}
+
+	return baseStyle.Render("")
 }
 
 func buildSelector(isSelected bool) string {

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -416,8 +416,20 @@ func TestBuildPullRequestAlert(t *testing.T) {
 			contains: "█",
 		},
 		{
-			name:    "no blocked prs shows empty",
-			state:   domain.PullRequestCount{MyBlocked: 0},
+			name:     "ready my prs show success spinner",
+			state:    domain.PullRequestCount{MyReady: 2},
+			runtime:  InfoRuntime{ReadySpinner: "●"},
+			contains: "●",
+		},
+		{
+			name:     "blocked takes precedence over ready",
+			state:    domain.PullRequestCount{MyBlocked: 1, MyReady: 2},
+			runtime:  InfoRuntime{BlockedSpinner: "█", ReadySpinner: "●"},
+			contains: "█",
+		},
+		{
+			name:    "no blocked or ready prs shows empty",
+			state:   domain.PullRequestCount{MyBlocked: 0, MyReady: 0},
 			runtime: InfoRuntime{},
 			isEmpty: true,
 		},
@@ -841,7 +853,7 @@ func TestRepositoryToRow(t *testing.T) {
 	}
 
 	if strings.TrimSpace(row[6]) != "" {
-		t.Errorf("row[6] (pr alert) = %q, want empty when no blocked PRs", row[6])
+		t.Errorf("row[6] (pr alert) = %q, want empty when no blocked/ready PRs", row[6])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a green pulse alert indicator for repositories with mergeable (ready) PRs
- keep blocked PR alerts as higher priority than ready alerts when both are present
- classify PRs with no review requirement as ready when checks are clear
- keep REVIEW_REQUIRED as review, and treat UNSTABLE as checks

## Testing
- mise x -- go test ./...