### PR TITLE
fix(listing): hide blocked alert spinner during PR sync

### DIFF
--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -75,6 +75,9 @@ func buildPullRequestAlert(state domain.PullRequestState, runtime InfoRuntime) s
 	if !ok || s.MyBlocked <= 0 {
 		return baseStyle.Render("")
 	}
+	if runtime.PullRequestSyncing {
+		return baseStyle.Render("")
+	}
 
 	frame := runtime.BlockedSpinner
 	if frame == "" {
@@ -214,10 +217,6 @@ func buildPullRequestStatus(state domain.PullRequestState, runtime InfoRuntime) 
 	baseStyle := common.PullRequestStatusBaseStyle.
 		Width(PRWidth).
 		MaxWidth(PRWidth)
-
-	if runtime.PullRequestSyncing {
-		return baseStyle.Render(runtime.PullRequestSpinner)
-	}
 
 	switch s := state.(type) {
 	case domain.PullRequestCount:

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -379,17 +379,17 @@ func TestBuildPullRequestStatus_MyOpenUsesWhiteMarker(t *testing.T) {
 	}
 }
 
-func TestBuildPullRequestStatus_SyncingShowsSpinnerOnly(t *testing.T) {
+func TestBuildPullRequestStatus_SyncingKeepsCurrentStateVisible(t *testing.T) {
 	t.Parallel()
 
 	runtime := InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋"}
 	got := buildPullRequestStatus(domain.PullRequestCount{Open: 9, MyOpen: 1}, runtime)
 
-	if !strings.Contains(got, "⠋") {
-		t.Fatalf("buildPullRequestStatus() = %q, want spinner", got)
+	if strings.Contains(got, "⠋") {
+		t.Fatalf("buildPullRequestStatus() = %q, want spinner hidden while syncing", got)
 	}
-	if strings.Contains(got, "9") || strings.Contains(got, "(*)") {
-		t.Fatalf("buildPullRequestStatus() = %q, want spinner-only content", got)
+	if !strings.Contains(got, "9") || !strings.Contains(got, "(*)") {
+		t.Fatalf("buildPullRequestStatus() = %q, want existing PR summary preserved", got)
 	}
 }
 
@@ -404,9 +404,9 @@ func TestBuildPullRequestAlert(t *testing.T) {
 		isEmpty  bool
 	}{
 		{
-			name:    "syncing keeps alert empty",
-			state:   domain.PullRequestCount{Open: 9, MyOpen: 1},
-			runtime: InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋"},
+			name:    "syncing hides alert even when blocked prs exist",
+			state:   domain.PullRequestCount{Open: 9, MyOpen: 1, MyBlocked: 2},
+			runtime: InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋", BlockedSpinner: "█"},
 			isEmpty: true,
 		},
 		{


### PR DESCRIPTION
## Summary
- hide the blocked PR alert spinner while pull request sync is in flight
- keep existing blocked alert behavior unchanged outside sync windows
- update listing table tests to cover blocked-pr + syncing behavior

## Testing
- go test ./internal/ui/views/listing
