### PR TITLE
Refactor UI fixtures, truncate rendering, and Update cmd flow

### DIFF
--- a/internal/ui/test_helpers_test.go
+++ b/internal/ui/test_helpers_test.go
@@ -21,18 +21,37 @@ func makeTestRepository(name string, opts ...testRepositoryOption) domain.Reposi
 	return repo
 }
 
-func withRepoPath(path string) testRepositoryOption {
+func withRepo(overrides domain.Repository) testRepositoryOption {
 	return func(repo *domain.Repository) {
-		repo.Path = path
+		if overrides.Name != "" {
+			repo.Name = overrides.Name
+		}
+		if overrides.Path != "" {
+			repo.Path = overrides.Path
+		}
+		if overrides.RemoteURL != "" {
+			repo.RemoteURL = overrides.RemoteURL
+		}
+		if overrides.Activity != nil {
+			repo.Activity = overrides.Activity
+		}
+		if overrides.LocalState != nil {
+			repo.LocalState = overrides.LocalState
+		}
+		if overrides.RemoteState != nil {
+			repo.RemoteState = overrides.RemoteState
+		}
+		if overrides.PullRequests != nil {
+			repo.PullRequests = overrides.PullRequests
+		}
+		if overrides.Branches.Current != nil {
+			repo.Branches.Current = overrides.Branches.Current
+		}
+		if overrides.Branches.Merged != nil {
+			repo.Branches.Merged = append([]string(nil), overrides.Branches.Merged...)
+		}
+		if overrides.StashCount != 0 {
+			repo.StashCount = overrides.StashCount
+		}
 	}
-}
-
-func withRepoRemoteURL(remoteURL string) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.RemoteURL = remoteURL
-	}
-}
-
-func withRepoMutator(mutator func(*domain.Repository)) testRepositoryOption {
-	return mutator
 }

--- a/internal/ui/test_helpers_test.go
+++ b/internal/ui/test_helpers_test.go
@@ -1,0 +1,38 @@
+package ui
+
+import "fresh/internal/domain"
+
+type testRepositoryOption func(*domain.Repository)
+
+func makeTestRepository(name string, opts ...testRepositoryOption) domain.Repository {
+	repo := domain.Repository{
+		Name:        name,
+		Path:        "/tmp/" + name,
+		Activity:    domain.IdleActivity{},
+		LocalState:  domain.CleanLocalState{},
+		RemoteState: domain.Synced{},
+		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+	}
+
+	for _, opt := range opts {
+		opt(&repo)
+	}
+
+	return repo
+}
+
+func withRepoPath(path string) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.Path = path
+	}
+}
+
+func withRepoRemoteURL(remoteURL string) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.RemoteURL = remoteURL
+	}
+}
+
+func withRepoMutator(mutator func(*domain.Repository)) testRepositoryOption {
+	return mutator
+}

--- a/internal/ui/test_helpers_test.go
+++ b/internal/ui/test_helpers_test.go
@@ -2,56 +2,77 @@ package ui
 
 import "fresh/internal/domain"
 
-type testRepositoryOption func(*domain.Repository)
-
-func makeTestRepository(name string, opts ...testRepositoryOption) domain.Repository {
-	repo := domain.Repository{
-		Name:        name,
-		Path:        "/tmp/" + name,
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.CleanLocalState{},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-	}
-
-	for _, opt := range opts {
-		opt(&repo)
-	}
-
-	return repo
+func makeTestRepository(name string) domain.Repository {
+	return newTestRepository(name).Build()
 }
 
-func withRepo(overrides domain.Repository) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		if overrides.Name != "" {
-			repo.Name = overrides.Name
-		}
-		if overrides.Path != "" {
-			repo.Path = overrides.Path
-		}
-		if overrides.RemoteURL != "" {
-			repo.RemoteURL = overrides.RemoteURL
-		}
-		if overrides.Activity != nil {
-			repo.Activity = overrides.Activity
-		}
-		if overrides.LocalState != nil {
-			repo.LocalState = overrides.LocalState
-		}
-		if overrides.RemoteState != nil {
-			repo.RemoteState = overrides.RemoteState
-		}
-		if overrides.PullRequests != nil {
-			repo.PullRequests = overrides.PullRequests
-		}
-		if overrides.Branches.Current != nil {
-			repo.Branches.Current = overrides.Branches.Current
-		}
-		if overrides.Branches.Merged != nil {
-			repo.Branches.Merged = append([]string(nil), overrides.Branches.Merged...)
-		}
-		if overrides.StashCount != 0 {
-			repo.StashCount = overrides.StashCount
-		}
+type testRepositoryBuilder struct {
+	repo domain.Repository
+}
+
+func newTestRepository(name string) *testRepositoryBuilder {
+	return &testRepositoryBuilder{
+		repo: domain.Repository{
+			Name:        name,
+			Path:        "/tmp/" + name,
+			Activity:    domain.IdleActivity{},
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+		},
 	}
+}
+
+func (b *testRepositoryBuilder) Name(name string) *testRepositoryBuilder {
+	b.repo.Name = name
+	return b
+}
+
+func (b *testRepositoryBuilder) Path(path string) *testRepositoryBuilder {
+	b.repo.Path = path
+	return b
+}
+
+func (b *testRepositoryBuilder) RemoteURL(remoteURL string) *testRepositoryBuilder {
+	b.repo.RemoteURL = remoteURL
+	return b
+}
+
+func (b *testRepositoryBuilder) Activity(activity domain.Activity) *testRepositoryBuilder {
+	b.repo.Activity = activity
+	return b
+}
+
+func (b *testRepositoryBuilder) LocalState(state domain.LocalState) *testRepositoryBuilder {
+	b.repo.LocalState = state
+	return b
+}
+
+func (b *testRepositoryBuilder) RemoteState(state domain.RemoteState) *testRepositoryBuilder {
+	b.repo.RemoteState = state
+	return b
+}
+
+func (b *testRepositoryBuilder) PullRequests(state domain.PullRequestState) *testRepositoryBuilder {
+	b.repo.PullRequests = state
+	return b
+}
+
+func (b *testRepositoryBuilder) CurrentBranch(branch domain.Branch) *testRepositoryBuilder {
+	b.repo.Branches.Current = branch
+	return b
+}
+
+func (b *testRepositoryBuilder) MergedBranches(merged ...string) *testRepositoryBuilder {
+	b.repo.Branches.Merged = append([]string(nil), merged...)
+	return b
+}
+
+func (b *testRepositoryBuilder) StashCount(count int) *testRepositoryBuilder {
+	b.repo.StashCount = count
+	return b
+}
+
+func (b *testRepositoryBuilder) Build() domain.Repository {
+	return b.repo
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -19,13 +19,13 @@ const (
 )
 
 type MainModel struct {
-	currentView       CurrentView
-	scanningView      *scanning.Model
-	listingView       *listing.Model
-	pullRequestsView  *pullrequests.Model
-	pullRequestCache  map[string][]domain.PullRequestDetails
-	notifier          *notifications.Notifier
-	width, height     int
+	currentView      CurrentView
+	scanningView     *scanning.Model
+	listingView      *listing.Model
+	pullRequestsView *pullrequests.Model
+	pullRequestCache map[string][]domain.PullRequestDetails
+	notifier         *notifications.Notifier
+	width, height    int
 }
 
 func New(scanDir string, notifier ...*notifications.Notifier) *MainModel {
@@ -57,7 +57,6 @@ func (m *MainModel) Init() tea.Cmd {
 
 func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
-	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -95,16 +94,19 @@ func (m *MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch m.currentView {
 	case ScanningView:
-		m.scanningView, cmd = m.scanningView.Update(msg)
+		if m.scanningView != nil {
+			m.scanningView, cmd = m.scanningView.Update(msg)
+		}
 	case RepoListView:
-		m.listingView, cmd = m.listingView.Update(msg)
+		if m.listingView != nil {
+			m.listingView, cmd = m.listingView.Update(msg)
+		}
 	case RepoPRListView:
 		if m.pullRequestsView != nil {
 			m.pullRequestsView, cmd = m.pullRequestsView.Update(msg)
 		}
 	}
-	cmds = append(cmds, cmd)
-	return m, tea.Batch(cmds...)
+	return m, cmd
 }
 
 func (m *MainModel) View() tea.View {

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -91,8 +91,8 @@ func TestMainModel_DelegatesKeyMsgToListingInRepoListView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		makeTestRepository("a", withRepoPath("/a")),
-		makeTestRepository("b", withRepoPath("/b")),
+		makeTestRepository("a"),
+		makeTestRepository("b"),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 
@@ -110,9 +110,7 @@ func TestMainModel_EnterTransitionsToPullRequestView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		makeTestRepository("repo-a", withRepoMutator(func(repo *domain.Repository) {
-			repo.RemoteURL = "https://github.com/octo/repo-a"
-		})),
+		makeTestRepository("repo-a", withRepo(domain.Repository{RemoteURL: "https://github.com/octo/repo-a"})),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 
@@ -141,7 +139,7 @@ func TestMainModel_EscapeTransitionsBackToListingView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		makeTestRepository("repo-a", withRepoRemoteURL("https://github.com/octo/repo-a")),
+		makeTestRepository("repo-a", withRepo(domain.Repository{RemoteURL: "https://github.com/octo/repo-a"})),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 	_, openCmd := m.Update(tea.KeyPressMsg{Code: '\r'})

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -110,7 +110,7 @@ func TestMainModel_EnterTransitionsToPullRequestView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		makeTestRepository("repo-a", withRepo(domain.Repository{RemoteURL: "https://github.com/octo/repo-a"})),
+		newTestRepository("repo-a").RemoteURL("https://github.com/octo/repo-a").Build(),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 
@@ -139,7 +139,7 @@ func TestMainModel_EscapeTransitionsBackToListingView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		makeTestRepository("repo-a", withRepo(domain.Repository{RemoteURL: "https://github.com/octo/repo-a"})),
+		newTestRepository("repo-a").RemoteURL("https://github.com/octo/repo-a").Build(),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 	_, openCmd := m.Update(tea.KeyPressMsg{Code: '\r'})

--- a/internal/ui/tui_test.go
+++ b/internal/ui/tui_test.go
@@ -23,13 +23,7 @@ func TestMainModel_ScanFinishedMsg_TransitionsToListingView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		{
-			Name: "test-repo", Path: "/tmp/test-repo",
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
+		makeTestRepository("test-repo"),
 	}
 
 	msg := scanning.ScanFinishedMsg{Repos: repos}
@@ -97,8 +91,8 @@ func TestMainModel_DelegatesKeyMsgToListingInRepoListView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		{Name: "a", Path: "/a", Activity: domain.IdleActivity{}, LocalState: domain.CleanLocalState{}, RemoteState: domain.Synced{}, Branches: domain.Branches{Current: domain.OnBranch{Name: "main"}}},
-		{Name: "b", Path: "/b", Activity: domain.IdleActivity{}, LocalState: domain.CleanLocalState{}, RemoteState: domain.Synced{}, Branches: domain.Branches{Current: domain.OnBranch{Name: "main"}}},
+		makeTestRepository("a", withRepoPath("/a")),
+		makeTestRepository("b", withRepoPath("/b")),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 
@@ -116,15 +110,9 @@ func TestMainModel_EnterTransitionsToPullRequestView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		{
-			Name:        "repo-a",
-			Path:        "/tmp/repo-a",
-			RemoteURL:   "https://github.com/octo/repo-a",
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
+		makeTestRepository("repo-a", withRepoMutator(func(repo *domain.Repository) {
+			repo.RemoteURL = "https://github.com/octo/repo-a"
+		})),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 
@@ -153,15 +141,7 @@ func TestMainModel_EscapeTransitionsBackToListingView(t *testing.T) {
 	m := New(t.TempDir())
 
 	repos := []domain.Repository{
-		{
-			Name:        "repo-a",
-			Path:        "/tmp/repo-a",
-			RemoteURL:   "https://github.com/octo/repo-a",
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
+		makeTestRepository("repo-a", withRepoRemoteURL("https://github.com/octo/repo-a")),
 	}
 	m.Update(scanning.ScanFinishedMsg{Repos: repos})
 	_, openCmd := m.Update(tea.KeyPressMsg{Code: '\r'})

--- a/internal/ui/views/common/style.go
+++ b/internal/ui/views/common/style.go
@@ -208,6 +208,19 @@ func TruncateWithEllipsis(text string, maxWidth int) string {
 	return string(runes[:maxWidth-3]) + "..."
 }
 
+func RenderTruncatedText(text string, width int, style lipgloss.Style) string {
+	if width < 1 {
+		width = 1
+	}
+	if lipgloss.Width(text) > width {
+		text = TruncateWithEllipsis(text, width)
+	}
+	return style.
+		Width(width).
+		MaxWidth(width).
+		Render(text)
+}
+
 func FormatPullProgress(spinnerView string, lastLine string, width int) string {
 	return spinnerView + " " + PullProgressStyle.Width(width).Render(lastLine)
 }

--- a/internal/ui/views/listing/layout_test.go
+++ b/internal/ui/views/listing/layout_test.go
@@ -166,7 +166,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 			repos: []domain.Repository{
 				makeTestRepository(
 					"app",
-					withRepoCurrentBranch(domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}),
+					withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}}}),
 				),
 			},
 			terminalWidth: 200,
@@ -175,7 +175,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 		},
 		{
 			name:          "zero terminal width uses content-based widths",
-			repos:         []domain.Repository{makeTestRepository("my-project", withRepoCurrentBranch(domain.OnBranch{Name: "develop"}))},
+			repos:         []domain.Repository{makeTestRepository("my-project", withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "develop"}}}))},
 			terminalWidth: 0,
 			wantProject:   MinProjectWidth,
 			wantBranch:    MinBranchWidth,
@@ -212,7 +212,7 @@ func TestCalculateColumnWidths_NarrowTerminal(t *testing.T) {
 func TestCalculateColumnWidths_DetachedHead(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("my-project", withRepoCurrentBranch(domain.DetachedHead{CommitSHA: "abc123"}))
+	repo := makeTestRepository("my-project", withRepo(domain.Repository{Branches: domain.Branches{Current: domain.DetachedHead{CommitSHA: "abc123"}}}))
 
 	// DetachedHead should use "HEAD" (4 chars) for branch width calculation
 	project, branch := calculateColumnWidths([]domain.Repository{repo}, 200)
@@ -231,7 +231,7 @@ func TestCalculateColumnWidths_MultipleRepos(t *testing.T) {
 		makeTestRepository("short"),
 		makeTestRepository(
 			"this-is-a-medium-length-name",
-			withRepoCurrentBranch(domain.OnBranch{Name: "feature/long-branch"}),
+			withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "feature/long-branch"}}}),
 		),
 	}
 

--- a/internal/ui/views/listing/layout_test.go
+++ b/internal/ui/views/listing/layout_test.go
@@ -164,10 +164,9 @@ func TestCalculateColumnWidths(t *testing.T) {
 		{
 			name: "long branch name clamped to max",
 			repos: []domain.Repository{
-				makeTestRepository(
-					"app",
-					withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}}}),
-				),
+				newTestRepository("app").
+					CurrentBranch(domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}).
+					Build(),
 			},
 			terminalWidth: 200,
 			wantProject:   MinProjectWidth,
@@ -175,7 +174,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 		},
 		{
 			name:          "zero terminal width uses content-based widths",
-			repos:         []domain.Repository{makeTestRepository("my-project", withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "develop"}}}))},
+			repos:         []domain.Repository{newTestRepository("my-project").CurrentBranch(domain.OnBranch{Name: "develop"}).Build()},
 			terminalWidth: 0,
 			wantProject:   MinProjectWidth,
 			wantBranch:    MinBranchWidth,
@@ -212,7 +211,7 @@ func TestCalculateColumnWidths_NarrowTerminal(t *testing.T) {
 func TestCalculateColumnWidths_DetachedHead(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("my-project", withRepo(domain.Repository{Branches: domain.Branches{Current: domain.DetachedHead{CommitSHA: "abc123"}}}))
+	repo := newTestRepository("my-project").CurrentBranch(domain.DetachedHead{CommitSHA: "abc123"}).Build()
 
 	// DetachedHead should use "HEAD" (4 chars) for branch width calculation
 	project, branch := calculateColumnWidths([]domain.Repository{repo}, 200)
@@ -229,10 +228,7 @@ func TestCalculateColumnWidths_MultipleRepos(t *testing.T) {
 
 	repos := []domain.Repository{
 		makeTestRepository("short"),
-		makeTestRepository(
-			"this-is-a-medium-length-name",
-			withRepo(domain.Repository{Branches: domain.Branches{Current: domain.OnBranch{Name: "feature/long-branch"}}}),
-		),
+		newTestRepository("this-is-a-medium-length-name").CurrentBranch(domain.OnBranch{Name: "feature/long-branch"}).Build(),
 	}
 
 	project, branch := calculateColumnWidths(repos, 200)

--- a/internal/ui/views/listing/layout_test.go
+++ b/internal/ui/views/listing/layout_test.go
@@ -131,17 +131,6 @@ func TestDistributeWidth_RespectsMaximums(t *testing.T) {
 func TestCalculateColumnWidths(t *testing.T) {
 	t.Parallel()
 
-	makeRepo := func(name string, branch domain.Branch) domain.Repository {
-		return domain.Repository{
-			Name:        name,
-			Path:        "/tmp/" + name,
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: branch},
-		}
-	}
-
 	tests := []struct {
 		name          string
 		repos         []domain.Repository
@@ -158,7 +147,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 		},
 		{
 			name:          "short names clamped to minimums",
-			repos:         []domain.Repository{makeRepo("app", domain.OnBranch{Name: "main"})},
+			repos:         []domain.Repository{makeTestRepository("app")},
 			terminalWidth: 200,
 			wantProject:   MinProjectWidth,
 			wantBranch:    MinBranchWidth,
@@ -166,7 +155,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 		{
 			name: "long project name clamped to max",
 			repos: []domain.Repository{
-				makeRepo("this-is-a-very-long-repository-name-that-exceeds-the-maximum", domain.OnBranch{Name: "main"}),
+				makeTestRepository("this-is-a-very-long-repository-name-that-exceeds-the-maximum"),
 			},
 			terminalWidth: 200,
 			wantProject:   MaxProjectWidth,
@@ -175,7 +164,10 @@ func TestCalculateColumnWidths(t *testing.T) {
 		{
 			name: "long branch name clamped to max",
 			repos: []domain.Repository{
-				makeRepo("app", domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}),
+				makeTestRepository(
+					"app",
+					withRepoCurrentBranch(domain.OnBranch{Name: "feature/very-long-branch-name-that-is-too-wide"}),
+				),
 			},
 			terminalWidth: 200,
 			wantProject:   MinProjectWidth,
@@ -183,7 +175,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 		},
 		{
 			name:          "zero terminal width uses content-based widths",
-			repos:         []domain.Repository{makeRepo("my-project", domain.OnBranch{Name: "develop"})},
+			repos:         []domain.Repository{makeTestRepository("my-project", withRepoCurrentBranch(domain.OnBranch{Name: "develop"}))},
 			terminalWidth: 0,
 			wantProject:   MinProjectWidth,
 			wantBranch:    MinBranchWidth,
@@ -205,14 +197,7 @@ func TestCalculateColumnWidths(t *testing.T) {
 func TestCalculateColumnWidths_NarrowTerminal(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name:        "my-project",
-		Path:        "/tmp/my-project",
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.CleanLocalState{},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-	}
+	repo := makeTestRepository("my-project")
 
 	// Very narrow terminal — available should go negative, returning minimums
 	project, branch := calculateColumnWidths([]domain.Repository{repo}, 10)
@@ -227,14 +212,7 @@ func TestCalculateColumnWidths_NarrowTerminal(t *testing.T) {
 func TestCalculateColumnWidths_DetachedHead(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name:        "my-project",
-		Path:        "/tmp/my-project",
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.CleanLocalState{},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.DetachedHead{CommitSHA: "abc123"}},
-	}
+	repo := makeTestRepository("my-project", withRepoCurrentBranch(domain.DetachedHead{CommitSHA: "abc123"}))
 
 	// DetachedHead should use "HEAD" (4 chars) for branch width calculation
 	project, branch := calculateColumnWidths([]domain.Repository{repo}, 200)
@@ -250,18 +228,11 @@ func TestCalculateColumnWidths_MultipleRepos(t *testing.T) {
 	t.Parallel()
 
 	repos := []domain.Repository{
-		{
-			Name: "short", Path: "/tmp/short",
-			Activity: domain.IdleActivity{}, LocalState: domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
-		{
-			Name: "this-is-a-medium-length-name", Path: "/tmp/medium",
-			Activity: domain.IdleActivity{}, LocalState: domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "feature/long-branch"}},
-		},
+		makeTestRepository("short"),
+		makeTestRepository(
+			"this-is-a-medium-length-name",
+			withRepoCurrentBranch(domain.OnBranch{Name: "feature/long-branch"}),
+		),
 	}
 
 	project, branch := calculateColumnWidths(repos, 200)

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -113,20 +113,9 @@ func buildSelector(isSelected bool) string {
 }
 
 func buildProjectName(name string, isSelected bool, width int) string {
-	if width < 1 {
-		width = 1
-	}
-
-	displayName := name
-	if lipgloss.Width(name) > width {
-		displayName = common.TruncateWithEllipsis(name, width)
-	}
-
 	style := lipgloss.NewStyle().
 		Foreground(common.TextPrimary).
 		Align(lipgloss.Left).
-		Width(width).
-		MaxWidth(width).
 		Height(1).
 		MaxHeight(1).
 		AlignHorizontal(lipgloss.Left)
@@ -135,7 +124,7 @@ func buildProjectName(name string, isSelected bool, width int) string {
 		style = style.Bold(true)
 	}
 
-	return style.Render(displayName)
+	return common.RenderTruncatedText(name, width, style)
 }
 
 func buildBranchName(branch domain.Branch, width int) string {

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -241,32 +241,32 @@ func TestBuildRemoteStatus(t *testing.T) {
 		},
 		{
 			name:     "ahead shows ahead icon with count",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Ahead{Count: 3}})),
+			repo:     newTestRepository("repo").RemoteState(domain.Ahead{Count: 3}).Build(),
 			contains: []string{common.IconAhead, "3"},
 		},
 		{
 			name:     "behind shows behind icon with count",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Behind{Count: 5}})),
+			repo:     newTestRepository("repo").RemoteState(domain.Behind{Count: 5}).Build(),
 			contains: []string{common.IconBehind, "5"},
 		},
 		{
 			name:     "diverged shows both ahead and behind counts",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Diverged{AheadCount: 2, BehindCount: 7}})),
+			repo:     newTestRepository("repo").RemoteState(domain.Diverged{AheadCount: 2, BehindCount: 7}).Build(),
 			contains: []string{common.IconAhead, "2", common.IconBehind, "7"},
 		},
 		{
 			name:     "no upstream shows dash",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.NoUpstream{}})),
+			repo:     newTestRepository("repo").RemoteState(domain.NoUpstream{}).Build(),
 			contains: []string{"-"},
 		},
 		{
 			name:     "detached remote shows dash",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.DetachedRemote{}})),
+			repo:     newTestRepository("repo").RemoteState(domain.DetachedRemote{}).Build(),
 			contains: []string{"-"},
 		},
 		{
 			name:     "remote error shows error icon",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.RemoteError{Message: "timeout"}})),
+			repo:     newTestRepository("repo").RemoteState(domain.RemoteError{Message: "timeout"}).Build(),
 			contains: []string{common.IconRemoteError},
 		},
 	}
@@ -539,14 +539,13 @@ func TestBuildInfo(t *testing.T) {
 	}{
 		{
 			name: "idle with my pr summary shows summary in info",
-			repo: makeTestRepository(
-				"repo",
-				withRepo(domain.Repository{PullRequests: domain.PullRequestCount{
+			repo: newTestRepository("repo").
+				PullRequests(domain.PullRequestCount{
 					MyReady:   0,
 					MyBlocked: 1,
 					MyChecks:  2,
-				}}),
-			),
+				}).
+				Build(),
 			contains: []string{"My PRs:", "1 blocked", "2 checks"},
 		},
 		{
@@ -555,66 +554,63 @@ func TestBuildInfo(t *testing.T) {
 		},
 		{
 			name:     "idle with remote error shows error message",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.RemoteError{Message: "connection timed out"}})),
+			repo:     newTestRepository("repo").RemoteState(domain.RemoteError{Message: "connection timed out"}).Build(),
 			contains: []string{"connection timed out"},
 		},
 		{
 			name:     "idle with no upstream shows no upstream message",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.NoUpstream{}})),
+			repo:     newTestRepository("repo").RemoteState(domain.NoUpstream{}).Build(),
 			contains: []string{common.LabelNoUpstream},
 		},
 		{
 			name:     "idle with detached remote shows detached message",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.DetachedRemote{}})),
+			repo:     newTestRepository("repo").RemoteState(domain.DetachedRemote{}).Build(),
 			contains: []string{common.LabelDetached},
 		},
 		{
 			name:     "idle with diverged remote shows diverged message",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Diverged{AheadCount: 1, BehindCount: 2}})),
+			repo:     newTestRepository("repo").RemoteState(domain.Diverged{AheadCount: 1, BehindCount: 2}).Build(),
 			contains: []string{common.StatusDiverged},
 		},
 		{
 			name:     "idle with prunable branches shows prune count",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{Branches: domain.Branches{Merged: []string{"feature-a", "feature-b"}}})),
+			repo:     newTestRepository("repo").MergedBranches("feature-a", "feature-b").Build(),
 			contains: []string{"2 prunable branches"},
 		},
 		{
 			name:     "idle with single prunable branch uses singular",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{Branches: domain.Branches{Merged: []string{"feature-a"}}})),
+			repo:     newTestRepository("repo").MergedBranches("feature-a").Build(),
 			contains: []string{"1 prunable branch"},
 		},
 		{
 			name:     "idle with one stash uses singular stash label",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{StashCount: 1})),
+			repo:     newTestRepository("repo").StashCount(1).Build(),
 			contains: []string{"1 stash"},
 		},
 		{
 			name:     "idle with multiple stashes uses plural stash label",
-			repo:     makeTestRepository("repo", withRepo(domain.Repository{StashCount: 3})),
+			repo:     newTestRepository("repo").StashCount(3).Build(),
 			contains: []string{"3 stashes"},
 		},
 		{
 			name: "idle with stash and prunable branches prefers prunable info",
-			repo: makeTestRepository("repo", withRepo(domain.Repository{
-				StashCount: 2,
-				Branches:   domain.Branches{Merged: []string{"feature-a"}},
-			})),
+			repo: newTestRepository("repo").
+				StashCount(2).
+				MergedBranches("feature-a").
+				Build(),
 			contains: []string{"1 prunable branch"},
 		},
 		{
 			name: "idle with remote error and stash prefers remote error",
-			repo: makeTestRepository(
-				"repo",
-				withRepo(domain.Repository{
-					RemoteState: domain.RemoteError{Message: "connection timed out"},
-					StashCount:  4,
-				}),
-			),
+			repo: newTestRepository("repo").
+				RemoteState(domain.RemoteError{Message: "connection timed out"}).
+				StashCount(4).
+				Build(),
 			contains: []string{"connection timed out"},
 		},
 		{
 			name: "refreshing in progress shows empty info",
-			repo: makeTestRepository("repo", withRepo(domain.Repository{Activity: &domain.RefreshingActivity{Complete: false}})),
+			repo: newTestRepository("repo").Activity(&domain.RefreshingActivity{Complete: false}).Build(),
 		},
 	}
 
@@ -714,10 +710,12 @@ func TestStylePullOutput(t *testing.T) {
 func TestRepositoryToRow(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("test-repo", withRepo(domain.Repository{PullRequests: domain.PullRequestCount{
-		Open:   2,
-		MyOpen: 1,
-	}}))
+	repo := newTestRepository("test-repo").
+		PullRequests(domain.PullRequestCount{
+			Open:   2,
+			MyOpen: 1,
+		}).
+		Build()
 
 	row := repositoryToRow(repo, true, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 
@@ -762,15 +760,12 @@ func TestRepositoryToRow(t *testing.T) {
 func TestRepositoryToRow_NotSelected(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository(
-		"another-repo",
-		withRepo(domain.Repository{
-			LocalState:   domain.DirtyLocalState{Modified: 2},
-			RemoteState:  domain.Behind{Count: 3},
-			PullRequests: domain.PullRequestCount{Open: 1, MyOpen: 0},
-			Branches:     domain.Branches{Current: domain.OnBranch{Name: "develop"}},
-		}),
-	)
+	repo := newTestRepository("another-repo").
+		LocalState(domain.DirtyLocalState{Modified: 2}).
+		RemoteState(domain.Behind{Count: 3}).
+		PullRequests(domain.PullRequestCount{Open: 1, MyOpen: 0}).
+		CurrentBranch(domain.OnBranch{Name: "develop"}).
+		Build()
 
 	row := repositoryToRow(repo, false, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -235,59 +235,38 @@ func TestBuildRemoteStatus(t *testing.T) {
 		contains []string
 	}{
 		{
-			name: "synced shows synced icon",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-			},
+			name:     "synced shows synced icon",
+			repo:     makeTestRepository("repo"),
 			contains: []string{common.IconSynced},
 		},
 		{
-			name: "ahead shows ahead icon with count",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Ahead{Count: 3},
-			},
+			name:     "ahead shows ahead icon with count",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Ahead{Count: 3})),
 			contains: []string{common.IconAhead, "3"},
 		},
 		{
-			name: "behind shows behind icon with count",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Behind{Count: 5},
-			},
+			name:     "behind shows behind icon with count",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Behind{Count: 5})),
 			contains: []string{common.IconBehind, "5"},
 		},
 		{
-			name: "diverged shows both ahead and behind counts",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Diverged{AheadCount: 2, BehindCount: 7},
-			},
+			name:     "diverged shows both ahead and behind counts",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Diverged{AheadCount: 2, BehindCount: 7})),
 			contains: []string{common.IconAhead, "2", common.IconBehind, "7"},
 		},
 		{
-			name: "no upstream shows dash",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.NoUpstream{},
-			},
+			name:     "no upstream shows dash",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.NoUpstream{})),
 			contains: []string{"-"},
 		},
 		{
-			name: "detached remote shows dash",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.DetachedRemote{},
-			},
+			name:     "detached remote shows dash",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.DetachedRemote{})),
 			contains: []string{"-"},
 		},
 		{
-			name: "remote error shows error icon",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.RemoteError{Message: "timeout"},
-			},
+			name:     "remote error shows error icon",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.RemoteError{Message: "timeout"})),
 			contains: []string{common.IconRemoteError},
 		},
 	}
@@ -532,7 +511,7 @@ func TestBuildMyPullRequestSummary_BlockedIsPinned(t *testing.T) {
 func TestBuildInfo_UsesRecentActivityOverStatus(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("demo")
+	repo := makeTestRepository("demo", withRepoPath("/tmp/demo"))
 
 	runtime := InfoRuntime{
 		Phase:                0,
@@ -560,136 +539,80 @@ func TestBuildInfo(t *testing.T) {
 	}{
 		{
 			name: "idle with my pr summary shows summary in info",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				PullRequests: domain.PullRequestCount{
+			repo: makeTestRepository(
+				"repo",
+				withRepoPullRequests(domain.PullRequestCount{
 					MyReady:   0,
 					MyBlocked: 1,
 					MyChecks:  2,
-				},
-				Branches: domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+				}),
+			),
 			contains: []string{"My PRs:", "1 blocked", "2 checks"},
 		},
 		{
 			name: "idle with synced remote shows empty info",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			repo: makeTestRepository("repo"),
 		},
 		{
-			name: "idle with remote error shows error message",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.RemoteError{Message: "connection timed out"},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with remote error shows error message",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.RemoteError{Message: "connection timed out"})),
 			contains: []string{"connection timed out"},
 		},
 		{
-			name: "idle with no upstream shows no upstream message",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.NoUpstream{},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with no upstream shows no upstream message",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.NoUpstream{})),
 			contains: []string{common.LabelNoUpstream},
 		},
 		{
-			name: "idle with detached remote shows detached message",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.DetachedRemote{},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with detached remote shows detached message",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.DetachedRemote{})),
 			contains: []string{common.LabelDetached},
 		},
 		{
-			name: "idle with diverged remote shows diverged message",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Diverged{AheadCount: 1, BehindCount: 2},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with diverged remote shows diverged message",
+			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Diverged{AheadCount: 1, BehindCount: 2})),
 			contains: []string{common.StatusDiverged},
 		},
 		{
-			name: "idle with prunable branches shows prune count",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				Branches: domain.Branches{
-					Current: domain.OnBranch{Name: "main"},
-					Merged:  []string{"feature-a", "feature-b"},
-				},
-			},
+			name:     "idle with prunable branches shows prune count",
+			repo:     makeTestRepository("repo", withRepoMergedBranches("feature-a", "feature-b")),
 			contains: []string{"2 prunable branches"},
 		},
 		{
-			name: "idle with single prunable branch uses singular",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				Branches: domain.Branches{
-					Current: domain.OnBranch{Name: "main"},
-					Merged:  []string{"feature-a"},
-				},
-			},
+			name:     "idle with single prunable branch uses singular",
+			repo:     makeTestRepository("repo", withRepoMergedBranches("feature-a")),
 			contains: []string{"1 prunable branch"},
 		},
 		{
-			name: "idle with one stash uses singular stash label",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				StashCount:  1,
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with one stash uses singular stash label",
+			repo:     makeTestRepository("repo", withRepoStashCount(1)),
 			contains: []string{"1 stash"},
 		},
 		{
-			name: "idle with multiple stashes uses plural stash label",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				StashCount:  3,
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			name:     "idle with multiple stashes uses plural stash label",
+			repo:     makeTestRepository("repo", withRepoStashCount(3)),
 			contains: []string{"3 stashes"},
 		},
 		{
 			name: "idle with stash and prunable branches prefers prunable info",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.Synced{},
-				StashCount:  2,
-				Branches: domain.Branches{
-					Current: domain.OnBranch{Name: "main"},
-					Merged:  []string{"feature-a"},
-				},
-			},
+			repo: makeTestRepository("repo", withRepoMutator(func(repo *domain.Repository) {
+				repo.StashCount = 2
+				repo.Branches.Merged = []string{"feature-a"}
+			})),
 			contains: []string{"1 prunable branch"},
 		},
 		{
 			name: "idle with remote error and stash prefers remote error",
-			repo: domain.Repository{
-				Activity:    domain.IdleActivity{},
-				RemoteState: domain.RemoteError{Message: "connection timed out"},
-				StashCount:  4,
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			repo: makeTestRepository(
+				"repo",
+				withRepoRemoteState(domain.RemoteError{Message: "connection timed out"}),
+				withRepoStashCount(4),
+			),
 			contains: []string{"connection timed out"},
 		},
 		{
 			name: "refreshing in progress shows empty info",
-			repo: domain.Repository{
-				Activity:    &domain.RefreshingActivity{Complete: false},
-				RemoteState: domain.Synced{},
-				Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-			},
+			repo: makeTestRepository("repo", withRepoActivity(&domain.RefreshingActivity{Complete: false})),
 		},
 	}
 
@@ -789,20 +712,10 @@ func TestStylePullOutput(t *testing.T) {
 func TestRepositoryToRow(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name:        "test-repo",
-		Path:        "/tmp/test-repo",
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.CleanLocalState{},
-		RemoteState: domain.Synced{},
-		PullRequests: domain.PullRequestCount{
-			Open:   2,
-			MyOpen: 1,
-		},
-		Branches: domain.Branches{
-			Current: domain.OnBranch{Name: "main"},
-		},
-	}
+	repo := makeTestRepository("test-repo", withRepoPullRequests(domain.PullRequestCount{
+		Open:   2,
+		MyOpen: 1,
+	}))
 
 	row := repositoryToRow(repo, true, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 
@@ -847,20 +760,13 @@ func TestRepositoryToRow(t *testing.T) {
 func TestRepositoryToRow_NotSelected(t *testing.T) {
 	t.Parallel()
 
-	repo := domain.Repository{
-		Name:        "another-repo",
-		Path:        "/tmp/another-repo",
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.DirtyLocalState{Modified: 2},
-		RemoteState: domain.Behind{Count: 3},
-		PullRequests: domain.PullRequestCount{
-			Open:   1,
-			MyOpen: 0,
-		},
-		Branches: domain.Branches{
-			Current: domain.OnBranch{Name: "develop"},
-		},
-	}
+	repo := makeTestRepository(
+		"another-repo",
+		withRepoLocalState(domain.DirtyLocalState{Modified: 2}),
+		withRepoRemoteState(domain.Behind{Count: 3}),
+		withRepoPullRequests(domain.PullRequestCount{Open: 1, MyOpen: 0}),
+		withRepoCurrentBranch(domain.OnBranch{Name: "develop"}),
+	)
 
 	row := repositoryToRow(repo, false, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -241,32 +241,32 @@ func TestBuildRemoteStatus(t *testing.T) {
 		},
 		{
 			name:     "ahead shows ahead icon with count",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Ahead{Count: 3})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Ahead{Count: 3}})),
 			contains: []string{common.IconAhead, "3"},
 		},
 		{
 			name:     "behind shows behind icon with count",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Behind{Count: 5})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Behind{Count: 5}})),
 			contains: []string{common.IconBehind, "5"},
 		},
 		{
 			name:     "diverged shows both ahead and behind counts",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Diverged{AheadCount: 2, BehindCount: 7})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Diverged{AheadCount: 2, BehindCount: 7}})),
 			contains: []string{common.IconAhead, "2", common.IconBehind, "7"},
 		},
 		{
 			name:     "no upstream shows dash",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.NoUpstream{})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.NoUpstream{}})),
 			contains: []string{"-"},
 		},
 		{
 			name:     "detached remote shows dash",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.DetachedRemote{})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.DetachedRemote{}})),
 			contains: []string{"-"},
 		},
 		{
 			name:     "remote error shows error icon",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.RemoteError{Message: "timeout"})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.RemoteError{Message: "timeout"}})),
 			contains: []string{common.IconRemoteError},
 		},
 	}
@@ -511,7 +511,7 @@ func TestBuildMyPullRequestSummary_BlockedIsPinned(t *testing.T) {
 func TestBuildInfo_UsesRecentActivityOverStatus(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("demo", withRepoPath("/tmp/demo"))
+	repo := makeTestRepository("demo")
 
 	runtime := InfoRuntime{
 		Phase:                0,
@@ -541,11 +541,11 @@ func TestBuildInfo(t *testing.T) {
 			name: "idle with my pr summary shows summary in info",
 			repo: makeTestRepository(
 				"repo",
-				withRepoPullRequests(domain.PullRequestCount{
+				withRepo(domain.Repository{PullRequests: domain.PullRequestCount{
 					MyReady:   0,
 					MyBlocked: 1,
 					MyChecks:  2,
-				}),
+				}}),
 			),
 			contains: []string{"My PRs:", "1 blocked", "2 checks"},
 		},
@@ -555,49 +555,49 @@ func TestBuildInfo(t *testing.T) {
 		},
 		{
 			name:     "idle with remote error shows error message",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.RemoteError{Message: "connection timed out"})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.RemoteError{Message: "connection timed out"}})),
 			contains: []string{"connection timed out"},
 		},
 		{
 			name:     "idle with no upstream shows no upstream message",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.NoUpstream{})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.NoUpstream{}})),
 			contains: []string{common.LabelNoUpstream},
 		},
 		{
 			name:     "idle with detached remote shows detached message",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.DetachedRemote{})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.DetachedRemote{}})),
 			contains: []string{common.LabelDetached},
 		},
 		{
 			name:     "idle with diverged remote shows diverged message",
-			repo:     makeTestRepository("repo", withRepoRemoteState(domain.Diverged{AheadCount: 1, BehindCount: 2})),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{RemoteState: domain.Diverged{AheadCount: 1, BehindCount: 2}})),
 			contains: []string{common.StatusDiverged},
 		},
 		{
 			name:     "idle with prunable branches shows prune count",
-			repo:     makeTestRepository("repo", withRepoMergedBranches("feature-a", "feature-b")),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{Branches: domain.Branches{Merged: []string{"feature-a", "feature-b"}}})),
 			contains: []string{"2 prunable branches"},
 		},
 		{
 			name:     "idle with single prunable branch uses singular",
-			repo:     makeTestRepository("repo", withRepoMergedBranches("feature-a")),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{Branches: domain.Branches{Merged: []string{"feature-a"}}})),
 			contains: []string{"1 prunable branch"},
 		},
 		{
 			name:     "idle with one stash uses singular stash label",
-			repo:     makeTestRepository("repo", withRepoStashCount(1)),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{StashCount: 1})),
 			contains: []string{"1 stash"},
 		},
 		{
 			name:     "idle with multiple stashes uses plural stash label",
-			repo:     makeTestRepository("repo", withRepoStashCount(3)),
+			repo:     makeTestRepository("repo", withRepo(domain.Repository{StashCount: 3})),
 			contains: []string{"3 stashes"},
 		},
 		{
 			name: "idle with stash and prunable branches prefers prunable info",
-			repo: makeTestRepository("repo", withRepoMutator(func(repo *domain.Repository) {
-				repo.StashCount = 2
-				repo.Branches.Merged = []string{"feature-a"}
+			repo: makeTestRepository("repo", withRepo(domain.Repository{
+				StashCount: 2,
+				Branches:   domain.Branches{Merged: []string{"feature-a"}},
 			})),
 			contains: []string{"1 prunable branch"},
 		},
@@ -605,14 +605,16 @@ func TestBuildInfo(t *testing.T) {
 			name: "idle with remote error and stash prefers remote error",
 			repo: makeTestRepository(
 				"repo",
-				withRepoRemoteState(domain.RemoteError{Message: "connection timed out"}),
-				withRepoStashCount(4),
+				withRepo(domain.Repository{
+					RemoteState: domain.RemoteError{Message: "connection timed out"},
+					StashCount:  4,
+				}),
 			),
 			contains: []string{"connection timed out"},
 		},
 		{
 			name: "refreshing in progress shows empty info",
-			repo: makeTestRepository("repo", withRepoActivity(&domain.RefreshingActivity{Complete: false})),
+			repo: makeTestRepository("repo", withRepo(domain.Repository{Activity: &domain.RefreshingActivity{Complete: false}})),
 		},
 	}
 
@@ -712,10 +714,10 @@ func TestStylePullOutput(t *testing.T) {
 func TestRepositoryToRow(t *testing.T) {
 	t.Parallel()
 
-	repo := makeTestRepository("test-repo", withRepoPullRequests(domain.PullRequestCount{
+	repo := makeTestRepository("test-repo", withRepo(domain.Repository{PullRequests: domain.PullRequestCount{
 		Open:   2,
 		MyOpen: 1,
-	}))
+	}}))
 
 	row := repositoryToRow(repo, true, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})
 
@@ -762,10 +764,12 @@ func TestRepositoryToRow_NotSelected(t *testing.T) {
 
 	repo := makeTestRepository(
 		"another-repo",
-		withRepoLocalState(domain.DirtyLocalState{Modified: 2}),
-		withRepoRemoteState(domain.Behind{Count: 3}),
-		withRepoPullRequests(domain.PullRequestCount{Open: 1, MyOpen: 0}),
-		withRepoCurrentBranch(domain.OnBranch{Name: "develop"}),
+		withRepo(domain.Repository{
+			LocalState:   domain.DirtyLocalState{Modified: 2},
+			RemoteState:  domain.Behind{Count: 3},
+			PullRequests: domain.PullRequestCount{Open: 1, MyOpen: 0},
+			Branches:     domain.Branches{Current: domain.OnBranch{Name: "develop"}},
+		}),
 	)
 
 	row := repositoryToRow(repo, false, ColumnLayout{ProjectWidth: 30, BranchWidth: 20, InfoWidth: InfoWidth}, InfoRuntime{})

--- a/internal/ui/views/listing/test_helpers_test.go
+++ b/internal/ui/views/listing/test_helpers_test.go
@@ -21,54 +21,37 @@ func makeTestRepository(name string, opts ...testRepositoryOption) domain.Reposi
 	return repo
 }
 
-func withRepoPath(path string) testRepositoryOption {
+func withRepo(overrides domain.Repository) testRepositoryOption {
 	return func(repo *domain.Repository) {
-		repo.Path = path
+		if overrides.Name != "" {
+			repo.Name = overrides.Name
+		}
+		if overrides.Path != "" {
+			repo.Path = overrides.Path
+		}
+		if overrides.RemoteURL != "" {
+			repo.RemoteURL = overrides.RemoteURL
+		}
+		if overrides.Activity != nil {
+			repo.Activity = overrides.Activity
+		}
+		if overrides.LocalState != nil {
+			repo.LocalState = overrides.LocalState
+		}
+		if overrides.RemoteState != nil {
+			repo.RemoteState = overrides.RemoteState
+		}
+		if overrides.PullRequests != nil {
+			repo.PullRequests = overrides.PullRequests
+		}
+		if overrides.Branches.Current != nil {
+			repo.Branches.Current = overrides.Branches.Current
+		}
+		if overrides.Branches.Merged != nil {
+			repo.Branches.Merged = append([]string(nil), overrides.Branches.Merged...)
+		}
+		if overrides.StashCount != 0 {
+			repo.StashCount = overrides.StashCount
+		}
 	}
-}
-
-func withRepoActivity(activity domain.Activity) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.Activity = activity
-	}
-}
-
-func withRepoLocalState(state domain.LocalState) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.LocalState = state
-	}
-}
-
-func withRepoRemoteState(state domain.RemoteState) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.RemoteState = state
-	}
-}
-
-func withRepoPullRequests(state domain.PullRequestState) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.PullRequests = state
-	}
-}
-
-func withRepoCurrentBranch(branch domain.Branch) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.Branches.Current = branch
-	}
-}
-
-func withRepoMergedBranches(merged ...string) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.Branches.Merged = append([]string(nil), merged...)
-	}
-}
-
-func withRepoStashCount(count int) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		repo.StashCount = count
-	}
-}
-
-func withRepoMutator(mutator func(*domain.Repository)) testRepositoryOption {
-	return mutator
 }

--- a/internal/ui/views/listing/test_helpers_test.go
+++ b/internal/ui/views/listing/test_helpers_test.go
@@ -2,56 +2,77 @@ package listing
 
 import "fresh/internal/domain"
 
-type testRepositoryOption func(*domain.Repository)
-
-func makeTestRepository(name string, opts ...testRepositoryOption) domain.Repository {
-	repo := domain.Repository{
-		Name:        name,
-		Path:        "/tmp/" + name,
-		Activity:    domain.IdleActivity{},
-		LocalState:  domain.CleanLocalState{},
-		RemoteState: domain.Synced{},
-		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-	}
-
-	for _, opt := range opts {
-		opt(&repo)
-	}
-
-	return repo
+func makeTestRepository(name string) domain.Repository {
+	return newTestRepository(name).Build()
 }
 
-func withRepo(overrides domain.Repository) testRepositoryOption {
-	return func(repo *domain.Repository) {
-		if overrides.Name != "" {
-			repo.Name = overrides.Name
-		}
-		if overrides.Path != "" {
-			repo.Path = overrides.Path
-		}
-		if overrides.RemoteURL != "" {
-			repo.RemoteURL = overrides.RemoteURL
-		}
-		if overrides.Activity != nil {
-			repo.Activity = overrides.Activity
-		}
-		if overrides.LocalState != nil {
-			repo.LocalState = overrides.LocalState
-		}
-		if overrides.RemoteState != nil {
-			repo.RemoteState = overrides.RemoteState
-		}
-		if overrides.PullRequests != nil {
-			repo.PullRequests = overrides.PullRequests
-		}
-		if overrides.Branches.Current != nil {
-			repo.Branches.Current = overrides.Branches.Current
-		}
-		if overrides.Branches.Merged != nil {
-			repo.Branches.Merged = append([]string(nil), overrides.Branches.Merged...)
-		}
-		if overrides.StashCount != 0 {
-			repo.StashCount = overrides.StashCount
-		}
+type testRepositoryBuilder struct {
+	repo domain.Repository
+}
+
+func newTestRepository(name string) *testRepositoryBuilder {
+	return &testRepositoryBuilder{
+		repo: domain.Repository{
+			Name:        name,
+			Path:        "/tmp/" + name,
+			Activity:    domain.IdleActivity{},
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+		},
 	}
+}
+
+func (b *testRepositoryBuilder) Name(name string) *testRepositoryBuilder {
+	b.repo.Name = name
+	return b
+}
+
+func (b *testRepositoryBuilder) Path(path string) *testRepositoryBuilder {
+	b.repo.Path = path
+	return b
+}
+
+func (b *testRepositoryBuilder) RemoteURL(remoteURL string) *testRepositoryBuilder {
+	b.repo.RemoteURL = remoteURL
+	return b
+}
+
+func (b *testRepositoryBuilder) Activity(activity domain.Activity) *testRepositoryBuilder {
+	b.repo.Activity = activity
+	return b
+}
+
+func (b *testRepositoryBuilder) LocalState(state domain.LocalState) *testRepositoryBuilder {
+	b.repo.LocalState = state
+	return b
+}
+
+func (b *testRepositoryBuilder) RemoteState(state domain.RemoteState) *testRepositoryBuilder {
+	b.repo.RemoteState = state
+	return b
+}
+
+func (b *testRepositoryBuilder) PullRequests(state domain.PullRequestState) *testRepositoryBuilder {
+	b.repo.PullRequests = state
+	return b
+}
+
+func (b *testRepositoryBuilder) CurrentBranch(branch domain.Branch) *testRepositoryBuilder {
+	b.repo.Branches.Current = branch
+	return b
+}
+
+func (b *testRepositoryBuilder) MergedBranches(merged ...string) *testRepositoryBuilder {
+	b.repo.Branches.Merged = append([]string(nil), merged...)
+	return b
+}
+
+func (b *testRepositoryBuilder) StashCount(count int) *testRepositoryBuilder {
+	b.repo.StashCount = count
+	return b
+}
+
+func (b *testRepositoryBuilder) Build() domain.Repository {
+	return b.repo
 }

--- a/internal/ui/views/listing/test_helpers_test.go
+++ b/internal/ui/views/listing/test_helpers_test.go
@@ -2,8 +2,10 @@ package listing
 
 import "fresh/internal/domain"
 
-func makeTestRepository(name string) domain.Repository {
-	return domain.Repository{
+type testRepositoryOption func(*domain.Repository)
+
+func makeTestRepository(name string, opts ...testRepositoryOption) domain.Repository {
+	repo := domain.Repository{
 		Name:        name,
 		Path:        "/tmp/" + name,
 		Activity:    domain.IdleActivity{},
@@ -11,4 +13,62 @@ func makeTestRepository(name string) domain.Repository {
 		RemoteState: domain.Synced{},
 		Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
 	}
+
+	for _, opt := range opts {
+		opt(&repo)
+	}
+
+	return repo
+}
+
+func withRepoPath(path string) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.Path = path
+	}
+}
+
+func withRepoActivity(activity domain.Activity) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.Activity = activity
+	}
+}
+
+func withRepoLocalState(state domain.LocalState) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.LocalState = state
+	}
+}
+
+func withRepoRemoteState(state domain.RemoteState) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.RemoteState = state
+	}
+}
+
+func withRepoPullRequests(state domain.PullRequestState) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.PullRequests = state
+	}
+}
+
+func withRepoCurrentBranch(branch domain.Branch) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.Branches.Current = branch
+	}
+}
+
+func withRepoMergedBranches(merged ...string) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.Branches.Merged = append([]string(nil), merged...)
+	}
+}
+
+func withRepoStashCount(count int) testRepositoryOption {
+	return func(repo *domain.Repository) {
+		repo.StashCount = count
+	}
+}
+
+func withRepoMutator(mutator func(*domain.Repository)) testRepositoryOption {
+	return mutator
 }

--- a/internal/ui/views/pullrequests/table.go
+++ b/internal/ui/views/pullrequests/table.go
@@ -67,18 +67,7 @@ func buildNumber(number int, mine bool) string {
 }
 
 func buildTitle(title string, mine bool, selected bool, width int) string {
-	if width < 1 {
-		width = 1
-	}
-
-	displayTitle := title
-	if lipgloss.Width(title) > width {
-		displayTitle = common.TruncateWithEllipsis(title, width)
-	}
-
 	style := lipgloss.NewStyle().
-		Width(width).
-		MaxWidth(width).
 		AlignHorizontal(lipgloss.Left)
 	if mine {
 		style = style.Foreground(common.Blue)
@@ -89,7 +78,7 @@ func buildTitle(title string, mine bool, selected bool, width int) string {
 		style = style.Bold(true)
 	}
 
-	return style.Render(displayTitle)
+	return common.RenderTruncatedText(title, width, style)
 }
 
 func buildCheckBar(checks domain.PullRequestChecks, width int, pulse bool) string {


### PR DESCRIPTION
## Summary
- expand test repository fixtures to option/mutator builders and replace repeated inline `domain.Repository` literals in:
  - `internal/ui/views/listing/table_test.go`
  - `internal/ui/views/listing/layout_test.go`
  - `internal/ui/tui_test.go`
- add `common.RenderTruncatedText` and reuse it in listing and pull request table title/repo rendering for consistent width+ellipsis behavior
- simplify `MainModel.Update` by returning a single command directly instead of batching a one-element slice, with nil guards on delegated view updates

## Verification
- `go test ./...`
