### PR TITLE
Include PR titles in desktop notifications

### DIFF
--- a/internal/git/pull_requests.go
+++ b/internal/git/pull_requests.go
@@ -47,6 +47,7 @@ type gqlPullRequestNode struct {
 	Repository struct {
 		NameWithOwner string `json:"nameWithOwner"`
 	} `json:"repository"`
+	Title            string  `json:"title"`
 	Number           int     `json:"number"`
 	IsDraft          bool    `json:"isDraft"`
 	ReviewDecision   *string `json:"reviewDecision"`
@@ -242,6 +243,7 @@ query($q: String!) {
         repository {
           nameWithOwner
         }
+        title
         number
         isDraft
         reviewDecision
@@ -306,6 +308,7 @@ query($q: String!) {
 				Number: row.Number,
 			},
 			Status: classification,
+			Title:  strings.TrimSpace(row.Title),
 		})
 
 		summary := summaries[ownerRepo]

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -26,11 +26,12 @@ func (k PRKey) String() string {
 }
 
 type Notification struct {
-	Key         PRKey
-	Kind        Kind
-	Reason      string
-	Repeat      bool
-	RepeatEvery time.Duration
+	Key              PRKey
+	Kind             Kind
+	Reason           string
+	PullRequestTitle string
+	Repeat           bool
+	RepeatEvery      time.Duration
 }
 
 type scheduledNotification struct {
@@ -177,6 +178,9 @@ func (n *Notifier) send(notification Notification) {
 
 func buildPayload(notification Notification) (title, body, soundPath string) {
 	title = notification.Key.Repo
+	if prTitle := strings.TrimSpace(notification.PullRequestTitle); prTitle != "" {
+		title = fmt.Sprintf("%s: %s", notification.Key.Repo, prTitle)
+	}
 
 	switch notification.Kind {
 	case KindBlocked:

--- a/internal/notifications/notifier_test.go
+++ b/internal/notifications/notifier_test.go
@@ -1,0 +1,43 @@
+package notifications
+
+import "testing"
+
+func TestBuildPayload_IncludesPullRequestTitleInNotificationTitle(t *testing.T) {
+	t.Parallel()
+
+	notification := Notification{
+		Key:              PRKey{Owner: "acme", Repo: "api", Number: 12},
+		Kind:             KindBlocked,
+		Reason:           "acme/api#12 is blocked",
+		PullRequestTitle: "Improve API docs",
+	}
+
+	title, body, soundPath := buildPayload(notification)
+
+	if title != "api: Improve API docs" {
+		t.Fatalf("title = %q, want %q", title, "api: Improve API docs")
+	}
+	if body != "Blocked - acme/api#12 is blocked" {
+		t.Fatalf("body = %q, want %q", body, "Blocked - acme/api#12 is blocked")
+	}
+	if soundPath != blowSoundPath {
+		t.Fatalf("soundPath = %q, want %q", soundPath, blowSoundPath)
+	}
+}
+
+func TestBuildPayload_WithoutPullRequestTitleUsesRepoName(t *testing.T) {
+	t.Parallel()
+
+	notification := Notification{
+		Key:              PRKey{Owner: "acme", Repo: "api", Number: 12},
+		Kind:             KindProgress,
+		Reason:           "acme/api#12 is mergeable",
+		PullRequestTitle: "   ",
+	}
+
+	title, _, _ := buildPayload(notification)
+
+	if title != "api" {
+		t.Fatalf("title = %q, want %q", title, "api")
+	}
+}

--- a/internal/pullrequests/coordinator.go
+++ b/internal/pullrequests/coordinator.go
@@ -44,22 +44,25 @@ func (c *NotificationCoordinator) Sync(tracked []Snapshot, options ApplyOptions,
 		switch change.Kind {
 		case ChangeBecameBlocked:
 			sink.Upsert(notifications.Notification{
-				Key:    key,
-				Kind:   notifications.KindBlocked,
-				Reason: fmt.Sprintf("%s is blocked", change.Key.String()),
+				Key:              key,
+				Kind:             notifications.KindBlocked,
+				Reason:           fmt.Sprintf("%s is blocked", change.Key.String()),
+				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameMergeable:
 			sink.Upsert(notifications.Notification{
-				Key:    key,
-				Kind:   notifications.KindProgress,
-				Reason: fmt.Sprintf("%s is mergeable", change.Key.String()),
+				Key:              key,
+				Kind:             notifications.KindProgress,
+				Reason:           fmt.Sprintf("%s is mergeable", change.Key.String()),
+				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameUnblocked:
 			sink.Resolve(key)
 			sink.Upsert(notifications.Notification{
-				Key:    key,
-				Kind:   notifications.KindProgress,
-				Reason: fmt.Sprintf("%s is no longer blocked", change.Key.String()),
+				Key:              key,
+				Kind:             notifications.KindProgress,
+				Reason:           fmt.Sprintf("%s is no longer blocked", change.Key.String()),
+				PullRequestTitle: change.Title,
 			})
 		case ChangeBlockedRemoved:
 			sink.Resolve(key)

--- a/internal/pullrequests/coordinator_test.go
+++ b/internal/pullrequests/coordinator_test.go
@@ -41,12 +41,12 @@ func TestNotificationCoordinator_BlockedTransitionUpsertsBlocked(t *testing.T) {
 
 	coordinator := NewNotificationCoordinator(nil)
 	_ = coordinator.Sync([]Snapshot{
-		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusReview},
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusReview, Title: "Improve API docs"},
 	}, ApplyOptions{Seed: true}, nil)
 
 	sink := &fakeNotificationSink{}
 	changes := coordinator.Sync([]Snapshot{
-		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked},
+		{Key: Key{Owner: "acme", Repo: "api", Number: 12}, Status: StatusBlocked, Title: "Improve API docs"},
 	}, ApplyOptions{}, sink)
 
 	if len(changes) != 1 || changes[0].Kind != ChangeBecameBlocked {
@@ -57,6 +57,9 @@ func TestNotificationCoordinator_BlockedTransitionUpsertsBlocked(t *testing.T) {
 	}
 	if sink.upserts[0].Kind != notifications.KindBlocked {
 		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindBlocked)
+	}
+	if sink.upserts[0].PullRequestTitle != "Improve API docs" {
+		t.Fatalf("pull request title = %q, want %q", sink.upserts[0].PullRequestTitle, "Improve API docs")
 	}
 }
 

--- a/internal/pullrequests/watchlist.go
+++ b/internal/pullrequests/watchlist.go
@@ -3,6 +3,7 @@ package pullrequests
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 type Status string
@@ -31,6 +32,7 @@ func (k Key) IsValid() bool {
 type Snapshot struct {
 	Key    Key
 	Status Status
+	Title  string
 }
 
 type ChangeKind string
@@ -47,6 +49,7 @@ type Change struct {
 	Key      Key
 	Previous Status
 	Current  Status
+	Title    string
 }
 
 type ApplyOptions struct {
@@ -57,12 +60,12 @@ type ApplyOptions struct {
 
 type Watchlist struct {
 	seeded  bool
-	tracked map[Key]Status
+	tracked map[Key]Snapshot
 }
 
 func NewWatchlist() *Watchlist {
 	return &Watchlist{
-		tracked: make(map[Key]Status),
+		tracked: make(map[Key]Snapshot),
 	}
 }
 
@@ -71,15 +74,17 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 		return nil
 	}
 	if w.tracked == nil {
-		w.tracked = make(map[Key]Status)
+		w.tracked = make(map[Key]Snapshot)
 	}
 
-	currentByKey := make(map[Key]Status, len(current))
+	currentByKey := make(map[Key]Snapshot, len(current))
 	for _, snapshot := range current {
 		if !snapshot.Key.IsValid() {
 			continue
 		}
-		currentByKey[snapshot.Key] = snapshot.Status
+
+		snapshot.Title = strings.TrimSpace(snapshot.Title)
+		currentByKey[snapshot.Key] = snapshot
 	}
 
 	if !w.seeded && options.Seed {
@@ -91,8 +96,15 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 	emitNewTransitions := w.seeded || !options.Seed
 	changes := make([]Change, 0)
 
-	for key, currentStatus := range currentByKey {
-		previousStatus, existed := w.tracked[key]
+	for key, currentSnapshot := range currentByKey {
+		currentStatus := currentSnapshot.Status
+		previousSnapshot, existed := w.tracked[key]
+		previousStatus := previousSnapshot.Status
+		title := currentSnapshot.Title
+		if title == "" {
+			title = previousSnapshot.Title
+		}
+
 		switch {
 		case !existed:
 			if !emitNewTransitions {
@@ -104,12 +116,14 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 					Kind:    ChangeBecameBlocked,
 					Key:     key,
 					Current: currentStatus,
+					Title:   title,
 				})
 			} else if currentStatus == StatusReady {
 				changes = append(changes, Change{
 					Kind:    ChangeBecameMergeable,
 					Key:     key,
 					Current: currentStatus,
+					Title:   title,
 				})
 			}
 		case previousStatus != currentStatus:
@@ -120,6 +134,7 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 					Key:      key,
 					Previous: previousStatus,
 					Current:  currentStatus,
+					Title:    title,
 				})
 			case currentStatus == StatusReady:
 				changes = append(changes, Change{
@@ -127,6 +142,7 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 					Key:      key,
 					Previous: previousStatus,
 					Current:  currentStatus,
+					Title:    title,
 				})
 			case previousStatus == StatusBlocked:
 				changes = append(changes, Change{
@@ -134,15 +150,17 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 					Key:      key,
 					Previous: previousStatus,
 					Current:  currentStatus,
+					Title:    title,
 				})
 			}
 		}
 	}
 
-	for key, previousStatus := range w.tracked {
+	for key, previousSnapshot := range w.tracked {
 		if _, ok := currentByKey[key]; ok {
 			continue
 		}
+		previousStatus := previousSnapshot.Status
 		if previousStatus != StatusBlocked {
 			continue
 		}
@@ -150,6 +168,7 @@ func (w *Watchlist) Apply(current []Snapshot, options ApplyOptions) []Change {
 			Kind:     ChangeBlockedRemoved,
 			Key:      key,
 			Previous: previousStatus,
+			Title:    previousSnapshot.Title,
 		})
 	}
 

--- a/internal/pullrequests/watchlist_test.go
+++ b/internal/pullrequests/watchlist_test.go
@@ -245,3 +245,61 @@ func TestWatchlist_IgnoresInvalidKeys(t *testing.T) {
 		t.Fatalf("changes = %d, want 0", len(changes))
 	}
 }
+
+func TestWatchlist_ChangeIncludesPullRequestTitle(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{
+			Key:    Key{Owner: "acme", Repo: "api", Number: 12},
+			Status: StatusReview,
+			Title:  "Improve API docs",
+		},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{
+			Key:    Key{Owner: "acme", Repo: "api", Number: 12},
+			Status: StatusBlocked,
+			Title:  "Improve API docs",
+		},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Title != "Improve API docs" {
+		t.Fatalf("title = %q, want %q", changes[0].Title, "Improve API docs")
+	}
+}
+
+func TestWatchlist_ChangeRetainsPreviousTitleWhenCurrentSnapshotOmitsIt(t *testing.T) {
+	t.Parallel()
+
+	watchlist := NewWatchlist()
+	watchlist.Apply([]Snapshot{
+		{
+			Key:    Key{Owner: "acme", Repo: "api", Number: 12},
+			Status: StatusBlocked,
+			Title:  "Fix flaky checks",
+		},
+	}, ApplyOptions{Seed: true})
+
+	changes := watchlist.Apply([]Snapshot{
+		{
+			Key:    Key{Owner: "acme", Repo: "api", Number: 12},
+			Status: StatusChecks,
+		},
+	}, ApplyOptions{})
+
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if changes[0].Kind != ChangeBecameUnblocked {
+		t.Fatalf("kind = %q, want %q", changes[0].Kind, ChangeBecameUnblocked)
+	}
+	if changes[0].Title != "Fix flaky checks" {
+		t.Fatalf("title = %q, want %q", changes[0].Title, "Fix flaky checks")
+	}
+}


### PR DESCRIPTION
## Summary
- fetch PR titles from GitHub in pull request sync
- carry PR title through watchlist changes and notification coordination
- include PR title in the desktop notification title when available
- add tests for payload formatting and title propagation

## Testing
- go test ./...