### PR TITLE
Pin and colorize My PR summary statuses

### DIFF
--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -7,6 +7,8 @@ import (
 
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/common"
+
+	"charm.land/lipgloss/v2"
 )
 
 type InfoTone int
@@ -17,6 +19,7 @@ const (
 	InfoToneSuccess
 	InfoToneWarn
 	InfoToneError
+	InfoTonePullRequestSummary
 )
 
 type InfoMessage struct {
@@ -56,7 +59,7 @@ func collectStatusInfoMessages(repo domain.Repository) []InfoMessage {
 	}
 
 	if summary, pinned := buildMyPullRequestSummary(repo.PullRequests); summary != "" {
-		appendMessage(InfoMessage{Text: summary, Tone: InfoToneSubtle, Pinned: pinned})
+		appendMessage(InfoMessage{Text: summary, Tone: InfoTonePullRequestSummary, Pinned: pinned})
 	}
 
 	mergedCount := len(repo.Branches.Merged)
@@ -200,10 +203,51 @@ func renderInfoMessage(msg InfoMessage, infoWidth int) string {
 		return common.PullOutputWarn.Width(infoWidth).Render(text)
 	case InfoToneError:
 		return common.PullOutputError.Width(infoWidth).Render(text)
+	case InfoTonePullRequestSummary:
+		return renderMyPullRequestSummaryInfo(text, infoWidth)
 	default:
 		return common.TextGrey.Render(text)
 	}
 }
+
+func renderMyPullRequestSummaryInfo(text string, infoWidth int) string {
+	text = common.TruncateWithEllipsis(text, infoWidth)
+
+	const prefix = "My PRs:"
+	if !strings.HasPrefix(text, prefix) {
+		return common.TextGrey.Render(text)
+	}
+
+	labelStyle := lipgloss.NewStyle().Foreground(common.TextPrimary)
+	separatorStyle := labelStyle
+	readyStyle := lipgloss.NewStyle().Foreground(common.Green)
+	blockedStyle := lipgloss.NewStyle().Foreground(common.Red)
+	waitingStyle := lipgloss.NewStyle().Foreground(common.Yellow)
+
+	rest := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+	if rest == "" {
+		return labelStyle.Render(prefix)
+	}
+
+	parts := strings.Split(rest, ", ")
+	rendered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		switch {
+		case strings.Contains(lower, "blocked"):
+			rendered = append(rendered, blockedStyle.Render(part))
+		case strings.Contains(lower, "ready"), strings.Contains(lower, "mergeable"):
+			rendered = append(rendered, readyStyle.Render(part))
+		case strings.Contains(lower, "check"), strings.Contains(lower, "review"), strings.Contains(lower, "waiting"):
+			rendered = append(rendered, waitingStyle.Render(part))
+		default:
+			rendered = append(rendered, labelStyle.Render(part))
+		}
+	}
+
+	return labelStyle.Render(prefix) + separatorStyle.Render(" ") + strings.Join(rendered, separatorStyle.Render(", "))
+}
+
 func normalizeInfoWidth(infoWidth int) int {
 	if infoWidth < 1 {
 		return 1

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -292,6 +292,7 @@ func buildMyPullRequestSummary(state domain.PullRequestState) (string, bool) {
 	hasPinned := false
 	if s.MyReady > 0 {
 		parts = append(parts, fmt.Sprintf("%d ready", s.MyReady))
+		hasPinned = true
 	}
 	if s.MyBlocked > 0 {
 		parts = append(parts, fmt.Sprintf("%d blocked", s.MyBlocked))

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -7,6 +7,8 @@ import (
 
 	"fresh/internal/domain"
 	"fresh/internal/ui/views/common"
+
+	"charm.land/lipgloss/v2"
 )
 
 // ============================================================================
@@ -505,6 +507,62 @@ func TestBuildMyPullRequestSummary_BlockedIsPinned(t *testing.T) {
 
 	if !strings.Contains(got, "2 blocked") {
 		t.Fatalf("summary = %q, want blocked count", got)
+	}
+}
+
+func TestBuildMyPullRequestSummary_ReadyIsPinned(t *testing.T) {
+	t.Parallel()
+
+	state := domain.PullRequestCount{MyReady: 1}
+
+	got, pinned := buildMyPullRequestSummary(state)
+
+	if !pinned {
+		t.Fatalf("buildMyPullRequestSummary() pinned = false, want true")
+	}
+
+	if !strings.Contains(got, "1 ready") {
+		t.Fatalf("summary = %q, want ready count", got)
+	}
+}
+
+func TestBuildInfo_MyPullRequestSummaryUsesStatusColors(t *testing.T) {
+	t.Parallel()
+
+	repo := newTestRepository("repo").
+		PullRequests(domain.PullRequestCount{
+			MyReady:   1,
+			MyBlocked: 2,
+			MyChecks:  3,
+			MyReview:  1,
+		}).
+		Build()
+
+	got := buildInfo(repo, 120, InfoRuntime{})
+
+	wantLabel := lipgloss.NewStyle().Foreground(common.TextPrimary).Render("My PRs:")
+	if !strings.Contains(got, wantLabel) {
+		t.Fatalf("buildInfo() = %q, want white label %q", got, wantLabel)
+	}
+
+	wantReady := lipgloss.NewStyle().Foreground(common.Green).Render("1 ready")
+	if !strings.Contains(got, wantReady) {
+		t.Fatalf("buildInfo() = %q, want green ready segment %q", got, wantReady)
+	}
+
+	wantBlocked := lipgloss.NewStyle().Foreground(common.Red).Render("2 blocked")
+	if !strings.Contains(got, wantBlocked) {
+		t.Fatalf("buildInfo() = %q, want red blocked segment %q", got, wantBlocked)
+	}
+
+	wantChecks := lipgloss.NewStyle().Foreground(common.Yellow).Render("3 checks")
+	if !strings.Contains(got, wantChecks) {
+		t.Fatalf("buildInfo() = %q, want yellow checks segment %q", got, wantChecks)
+	}
+
+	wantReview := lipgloss.NewStyle().Foreground(common.Yellow).Render("1 review")
+	if !strings.Contains(got, wantReview) {
+		t.Fatalf("buildInfo() = %q, want yellow review segment %q", got, wantReview)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep `My PRs:` label in white while colorizing status counts
- colorize blocked/ready/waiting-style buckets (blocked red, ready green, checks/review yellow)
- pin the My PR summary info line when either blocked or ready counts are non-zero
- add listing tests for color rendering and ready-based pinning

## Testing
- mise exec -- go test -v -race ./...
