### PR TITLE
Merge duplicated PR key types

### DIFF
--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -2,41 +2,23 @@ package notifications
 
 import (
 	"fmt"
+	"fresh/internal/pullrequests"
 	"os/exec"
 	"strings"
 	"sync"
 	"time"
 )
 
-type Kind string
+type Kind = pullrequests.NotificationKind
 
 const (
-	KindProgress Kind = "progress"
-	KindBlocked  Kind = "blocked"
+	KindProgress Kind = pullrequests.NotificationKindProgress
+	KindBlocked  Kind = pullrequests.NotificationKindBlocked
 )
 
-type PRKey struct {
-	Owner  string
-	Repo   string
-	Number int
-}
+type PRKey = pullrequests.Key
 
-func (k PRKey) String() string {
-	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Repo, k.Number)
-}
-
-func (k PRKey) IsValid() bool {
-	return k.Owner != "" && k.Repo != "" && k.Number > 0
-}
-
-type Notification struct {
-	Key              PRKey
-	Kind             Kind
-	Reason           string
-	PullRequestTitle string
-	Repeat           bool
-	RepeatEvery      time.Duration
-}
+type Notification = pullrequests.Notification
 
 type scheduledNotification struct {
 	notification Notification

--- a/internal/notifications/notifier.go
+++ b/internal/notifications/notifier.go
@@ -25,6 +25,10 @@ func (k PRKey) String() string {
 	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Repo, k.Number)
 }
 
+func (k PRKey) IsValid() bool {
+	return k.Owner != "" && k.Repo != "" && k.Number > 0
+}
+
 type Notification struct {
 	Key              PRKey
 	Kind             Kind
@@ -91,7 +95,7 @@ func (n *Notifier) Stop() {
 }
 
 func (n *Notifier) Upsert(notification Notification) {
-	if notification.Key.Owner == "" || notification.Key.Repo == "" || notification.Key.Number <= 0 {
+	if !notification.Key.IsValid() {
 		return
 	}
 

--- a/internal/pullrequests/coordinator.go
+++ b/internal/pullrequests/coordinator.go
@@ -2,12 +2,11 @@ package pullrequests
 
 import (
 	"fmt"
-	"fresh/internal/notifications"
 )
 
 type NotificationSink interface {
-	Upsert(notification notifications.Notification)
-	Resolve(key notifications.PRKey)
+	Upsert(notification Notification)
+	Resolve(key Key)
 }
 
 type NotificationCoordinator struct {
@@ -37,24 +36,24 @@ func (c *NotificationCoordinator) Sync(tracked []Snapshot, options ApplyOptions,
 	for _, change := range changes {
 		switch change.Kind {
 		case ChangeBecameBlocked:
-			sink.Upsert(notifications.Notification{
+			sink.Upsert(Notification{
 				Key:              change.Key,
-				Kind:             notifications.KindBlocked,
+				Kind:             NotificationKindBlocked,
 				Reason:           fmt.Sprintf("%s is blocked", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameMergeable:
-			sink.Upsert(notifications.Notification{
+			sink.Upsert(Notification{
 				Key:              change.Key,
-				Kind:             notifications.KindProgress,
+				Kind:             NotificationKindProgress,
 				Reason:           fmt.Sprintf("%s is mergeable", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameUnblocked:
 			sink.Resolve(change.Key)
-			sink.Upsert(notifications.Notification{
+			sink.Upsert(Notification{
 				Key:              change.Key,
-				Kind:             notifications.KindProgress,
+				Kind:             NotificationKindProgress,
 				Reason:           fmt.Sprintf("%s is no longer blocked", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})

--- a/internal/pullrequests/coordinator.go
+++ b/internal/pullrequests/coordinator.go
@@ -35,37 +35,31 @@ func (c *NotificationCoordinator) Sync(tracked []Snapshot, options ApplyOptions,
 	}
 
 	for _, change := range changes {
-		key := notifications.PRKey{
-			Owner:  change.Key.Owner,
-			Repo:   change.Key.Repo,
-			Number: change.Key.Number,
-		}
-
 		switch change.Kind {
 		case ChangeBecameBlocked:
 			sink.Upsert(notifications.Notification{
-				Key:              key,
+				Key:              change.Key,
 				Kind:             notifications.KindBlocked,
 				Reason:           fmt.Sprintf("%s is blocked", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameMergeable:
 			sink.Upsert(notifications.Notification{
-				Key:              key,
+				Key:              change.Key,
 				Kind:             notifications.KindProgress,
 				Reason:           fmt.Sprintf("%s is mergeable", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})
 		case ChangeBecameUnblocked:
-			sink.Resolve(key)
+			sink.Resolve(change.Key)
 			sink.Upsert(notifications.Notification{
-				Key:              key,
+				Key:              change.Key,
 				Kind:             notifications.KindProgress,
 				Reason:           fmt.Sprintf("%s is no longer blocked", change.Key.String()),
 				PullRequestTitle: change.Title,
 			})
 		case ChangeBlockedRemoved:
-			sink.Resolve(key)
+			sink.Resolve(change.Key)
 		}
 	}
 

--- a/internal/pullrequests/coordinator_test.go
+++ b/internal/pullrequests/coordinator_test.go
@@ -1,20 +1,19 @@
 package pullrequests
 
 import (
-	"fresh/internal/notifications"
 	"testing"
 )
 
 type fakeNotificationSink struct {
-	upserts  []notifications.Notification
-	resolves []notifications.PRKey
+	upserts  []Notification
+	resolves []Key
 }
 
-func (f *fakeNotificationSink) Upsert(notification notifications.Notification) {
+func (f *fakeNotificationSink) Upsert(notification Notification) {
 	f.upserts = append(f.upserts, notification)
 }
 
-func (f *fakeNotificationSink) Resolve(key notifications.PRKey) {
+func (f *fakeNotificationSink) Resolve(key Key) {
 	f.resolves = append(f.resolves, key)
 }
 
@@ -55,8 +54,8 @@ func TestNotificationCoordinator_BlockedTransitionUpsertsBlocked(t *testing.T) {
 	if len(sink.upserts) != 1 {
 		t.Fatalf("upserts = %d, want 1", len(sink.upserts))
 	}
-	if sink.upserts[0].Kind != notifications.KindBlocked {
-		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindBlocked)
+	if sink.upserts[0].Kind != NotificationKindBlocked {
+		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, NotificationKindBlocked)
 	}
 	if sink.upserts[0].PullRequestTitle != "Improve API docs" {
 		t.Fatalf("pull request title = %q, want %q", sink.upserts[0].PullRequestTitle, "Improve API docs")
@@ -85,8 +84,8 @@ func TestNotificationCoordinator_UnblockedTransitionResolvesThenProgress(t *test
 	if len(sink.upserts) != 1 {
 		t.Fatalf("upserts = %d, want 1", len(sink.upserts))
 	}
-	if sink.upserts[0].Kind != notifications.KindProgress {
-		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindProgress)
+	if sink.upserts[0].Kind != NotificationKindProgress {
+		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, NotificationKindProgress)
 	}
 }
 
@@ -112,8 +111,8 @@ func TestNotificationCoordinator_MergeableTransitionUpsertsProgress(t *testing.T
 	if len(sink.upserts) != 1 {
 		t.Fatalf("upserts = %d, want 1", len(sink.upserts))
 	}
-	if sink.upserts[0].Kind != notifications.KindProgress {
-		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, notifications.KindProgress)
+	if sink.upserts[0].Kind != NotificationKindProgress {
+		t.Fatalf("kind = %q, want %q", sink.upserts[0].Kind, NotificationKindProgress)
 	}
 }
 

--- a/internal/pullrequests/key.go
+++ b/internal/pullrequests/key.go
@@ -1,0 +1,5 @@
+package pullrequests
+
+import "fresh/internal/notifications"
+
+type Key = notifications.PRKey

--- a/internal/pullrequests/key.go
+++ b/internal/pullrequests/key.go
@@ -1,5 +1,17 @@
 package pullrequests
 
-import "fresh/internal/notifications"
+import "fmt"
 
-type Key = notifications.PRKey
+type Key struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+func (k Key) String() string {
+	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Repo, k.Number)
+}
+
+func (k Key) IsValid() bool {
+	return k.Owner != "" && k.Repo != "" && k.Number > 0
+}

--- a/internal/pullrequests/notification.go
+++ b/internal/pullrequests/notification.go
@@ -1,0 +1,19 @@
+package pullrequests
+
+import "time"
+
+type NotificationKind string
+
+const (
+	NotificationKindProgress NotificationKind = "progress"
+	NotificationKindBlocked  NotificationKind = "blocked"
+)
+
+type Notification struct {
+	Key              Key
+	Kind             NotificationKind
+	Reason           string
+	PullRequestTitle string
+	Repeat           bool
+	RepeatEvery      time.Duration
+}

--- a/internal/pullrequests/watchlist.go
+++ b/internal/pullrequests/watchlist.go
@@ -1,7 +1,6 @@
 package pullrequests
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
@@ -14,20 +13,6 @@ const (
 	StatusReview  Status = "review"
 	StatusChecks  Status = "checks"
 )
-
-type Key struct {
-	Owner  string
-	Repo   string
-	Number int
-}
-
-func (k Key) String() string {
-	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Repo, k.Number)
-}
-
-func (k Key) IsValid() bool {
-	return k.Owner != "" && k.Repo != "" && k.Number > 0
-}
 
 type Snapshot struct {
 	Key    Key


### PR DESCRIPTION
## Summary
- make `pullrequests.Key` the concrete PR key implementation (`Owner`, `Repo`, `Number`, `String`, `IsValid`)
- make `notifications` consume pull request types via aliases (`PRKey`, `Kind`, `Notification`)
- remove `pullrequests -> notifications` coupling in `NotificationCoordinator` by using pullrequest-owned notification types
- keep notifier repeat behavior intact for repeated notifications

## Testing
- `mise x -- go test ./...`
