### PR TITLE
Remove dead listing/scanning UI plumbing

### DIFF
--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -38,7 +38,6 @@ type InfoRuntime struct {
 	Now                  time.Time
 	RecentActivityByRepo map[string][]TimedInfoMessage
 	PullRequestSyncing   bool
-	PullRequestSpinner   string
 	BlockedSpinner       string
 	ReadySpinner         string
 }

--- a/internal/ui/views/listing/listing.go
+++ b/internal/ui/views/listing/listing.go
@@ -391,7 +391,6 @@ func (m *Model) View() string {
 		Now:                  time.Now(),
 		RecentActivityByRepo: m.RecentInfo,
 		PullRequestSyncing:   m.isPullRequestSyncInFlight(),
-		PullRequestSpinner:   m.pullRequestSpinnerView(),
 		BlockedSpinner:       m.BlockedSpinner.View(),
 		ReadySpinner:         m.ReadySpinner.View(),
 	}

--- a/internal/ui/views/listing/pull_request_sync.go
+++ b/internal/ui/views/listing/pull_request_sync.go
@@ -25,11 +25,3 @@ func (m *Model) completePullRequestSync() {
 func (m *Model) isPullRequestSyncInFlight() bool {
 	return m.PRSyncInFlight > 0
 }
-
-func (m *Model) pullRequestSpinnerView() string {
-	if !m.isPullRequestSyncInFlight() {
-		return ""
-	}
-
-	return m.PRSyncSpinner.View()
-}

--- a/internal/ui/views/listing/pull_request_sync_test.go
+++ b/internal/ui/views/listing/pull_request_sync_test.go
@@ -115,13 +115,6 @@ func TestUpdatePullRequestStatesIgnoresStaleGeneration(t *testing.T) {
 	}
 }
 
-func TestPullRequestSpinnerViewEmptyWhenNotSyncing(t *testing.T) {
-	m := New(nil)
-	if got := m.pullRequestSpinnerView(); got != "" {
-		t.Fatalf("pullRequestSpinnerView() = %q, want empty", got)
-	}
-}
-
 func TestStartRefreshCycleStartsPRSyncAndRepoRefresh(t *testing.T) {
 	m := New(sampleWatchRepos())
 

--- a/internal/ui/views/listing/table.go
+++ b/internal/ui/views/listing/table.go
@@ -311,7 +311,3 @@ func buildMyPullRequestSummary(state domain.PullRequestState) (string, bool) {
 
 	return "My PRs: " + strings.Join(parts, ", "), hasPinned
 }
-
-func stylePullOutput(lastLine string, exitCode int, infoWidth int) string {
-	return renderInfoMessage(buildPullOutputInfoMessage(lastLine, exitCode), normalizeInfoWidth(infoWidth))
-}

--- a/internal/ui/views/listing/table_test.go
+++ b/internal/ui/views/listing/table_test.go
@@ -350,7 +350,7 @@ func TestBuildPullRequestStatus(t *testing.T) {
 func TestBuildPullRequestStatus_SyncingKeepsCurrentStateVisible(t *testing.T) {
 	t.Parallel()
 
-	runtime := InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋"}
+	runtime := InfoRuntime{PullRequestSyncing: true}
 	got := buildPullRequestStatus(domain.PullRequestCount{Open: 9, MyOpen: 1}, runtime)
 
 	if strings.Contains(got, "⠋") {
@@ -374,7 +374,7 @@ func TestBuildPullRequestAlert(t *testing.T) {
 		{
 			name:    "syncing hides alert even when blocked prs exist",
 			state:   domain.PullRequestCount{Open: 9, MyOpen: 1, MyBlocked: 2},
-			runtime: InfoRuntime{PullRequestSyncing: true, PullRequestSpinner: "⠋", BlockedSpinner: "█"},
+			runtime: InfoRuntime{PullRequestSyncing: true, BlockedSpinner: "█"},
 			isEmpty: true,
 		},
 		{
@@ -681,81 +681,6 @@ func TestBuildInfo(t *testing.T) {
 					t.Errorf("buildInfo(%q) = %q, want it to contain %q",
 						tt.name, got, want)
 				}
-			}
-		})
-	}
-}
-
-// ============================================================================
-// stylePullOutput tests
-// ============================================================================
-
-func TestStylePullOutput(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		lastLine string
-		exitCode int
-		contains string
-	}{
-		{
-			name:     "error keyword in output",
-			lastLine: "error: could not apply patch",
-			exitCode: 1,
-			contains: "error: could not apply patch",
-		},
-		{
-			name:     "fatal keyword in output",
-			lastLine: "fatal: remote origin not found",
-			exitCode: 128,
-			contains: "fatal: remote origin not found",
-		},
-		{
-			name:     "success with up to date",
-			lastLine: "Already up to date.",
-			exitCode: 0,
-			contains: "Already up to date.",
-		},
-		{
-			name:     "success with up-to-date hyphenated",
-			lastLine: "Already up-to-date.",
-			exitCode: 0,
-			contains: "Already up-to-date.",
-		},
-		{
-			name:     "success with done message",
-			lastLine: "done.",
-			exitCode: 0,
-			contains: "done.",
-		},
-		{
-			name:     "success with file changed",
-			lastLine: "1 file changed, 5 insertions(+)",
-			exitCode: 0,
-			contains: "1 file changed",
-		},
-		{
-			name:     "non-zero exit unknown text falls through to warn",
-			lastLine: "something unexpected happened",
-			exitCode: 1,
-			contains: "something unexpected happened",
-		},
-		{
-			name:     "zero exit with unknown text falls through to warn",
-			lastLine: "some other output",
-			exitCode: 0,
-			contains: "some other output",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := stylePullOutput(tt.lastLine, tt.exitCode, InfoWidth)
-			if !strings.Contains(got, tt.contains) {
-				t.Errorf("stylePullOutput(%q, %d) = %q, want it to contain %q",
-					tt.lastLine, tt.exitCode, got, tt.contains)
 			}
 		})
 	}

--- a/internal/ui/views/scanning/scanning.go
+++ b/internal/ui/views/scanning/scanning.go
@@ -16,10 +16,9 @@ import (
 var cfg = config.DefaultConfig()
 
 type Model struct {
-	Repositories  []domain.Repository
-	scanner       *scanner.Scanner
-	Spinner       spinner.Model
-	width, height int
+	Repositories []domain.Repository
+	scanner      *scanner.Scanner
+	Spinner      spinner.Model
 }
 
 func New(scanDir string) *Model {
@@ -41,14 +40,6 @@ func (m *Model) Init() tea.Cmd {
 
 func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-		return m, nil
-
-	case tea.KeyPressMsg:
-		// Handle any key messages (optional, can be removed if not needed)
-
 	case repoFoundMsg:
 		path := string(msg)
 		repo := git.BuildRepository(path, cfg)


### PR DESCRIPTION
## Summary
- remove unused listing helper `stylePullOutput` and the tests that only exercised that dead path
- remove `InfoRuntime.PullRequestSpinner` write path and delete the now-unused `pullRequestSpinnerView` helper/test
- remove no-op scanning state (`width/height`) plus no-op `WindowSizeMsg` and `KeyPressMsg` branches

## Verification
- mise exec -- go test ./...
