### PR TITLE
Deduplicate test repository builders

### DIFF
--- a/internal/testhelpers/repository_builder.go
+++ b/internal/testhelpers/repository_builder.go
@@ -1,0 +1,74 @@
+package testhelpers
+
+import "fresh/internal/domain"
+
+type RepositoryBuilder struct {
+	repo domain.Repository
+}
+
+func NewTestRepository(name string) *RepositoryBuilder {
+	return &RepositoryBuilder{
+		repo: domain.Repository{
+			Name:        name,
+			Path:        "/tmp/" + name,
+			Activity:    domain.IdleActivity{},
+			LocalState:  domain.CleanLocalState{},
+			RemoteState: domain.Synced{},
+			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
+		},
+	}
+}
+
+func (b *RepositoryBuilder) Name(name string) *RepositoryBuilder {
+	b.repo.Name = name
+	return b
+}
+
+func (b *RepositoryBuilder) Path(path string) *RepositoryBuilder {
+	b.repo.Path = path
+	return b
+}
+
+func (b *RepositoryBuilder) RemoteURL(remoteURL string) *RepositoryBuilder {
+	b.repo.RemoteURL = remoteURL
+	return b
+}
+
+func (b *RepositoryBuilder) Activity(activity domain.Activity) *RepositoryBuilder {
+	b.repo.Activity = activity
+	return b
+}
+
+func (b *RepositoryBuilder) LocalState(state domain.LocalState) *RepositoryBuilder {
+	b.repo.LocalState = state
+	return b
+}
+
+func (b *RepositoryBuilder) RemoteState(state domain.RemoteState) *RepositoryBuilder {
+	b.repo.RemoteState = state
+	return b
+}
+
+func (b *RepositoryBuilder) PullRequests(state domain.PullRequestState) *RepositoryBuilder {
+	b.repo.PullRequests = state
+	return b
+}
+
+func (b *RepositoryBuilder) CurrentBranch(branch domain.Branch) *RepositoryBuilder {
+	b.repo.Branches.Current = branch
+	return b
+}
+
+func (b *RepositoryBuilder) MergedBranches(merged ...string) *RepositoryBuilder {
+	b.repo.Branches.Merged = append([]string(nil), merged...)
+	return b
+}
+
+func (b *RepositoryBuilder) StashCount(count int) *RepositoryBuilder {
+	b.repo.StashCount = count
+	return b
+}
+
+func (b *RepositoryBuilder) Build() domain.Repository {
+	return b.repo
+}

--- a/internal/ui/test_helpers_test.go
+++ b/internal/ui/test_helpers_test.go
@@ -1,78 +1,16 @@
 package ui
 
-import "fresh/internal/domain"
+import (
+	"fresh/internal/domain"
+	"fresh/internal/testhelpers"
+)
+
+type testRepositoryBuilder = testhelpers.RepositoryBuilder
 
 func makeTestRepository(name string) domain.Repository {
 	return newTestRepository(name).Build()
 }
 
-type testRepositoryBuilder struct {
-	repo domain.Repository
-}
-
 func newTestRepository(name string) *testRepositoryBuilder {
-	return &testRepositoryBuilder{
-		repo: domain.Repository{
-			Name:        name,
-			Path:        "/tmp/" + name,
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
-	}
-}
-
-func (b *testRepositoryBuilder) Name(name string) *testRepositoryBuilder {
-	b.repo.Name = name
-	return b
-}
-
-func (b *testRepositoryBuilder) Path(path string) *testRepositoryBuilder {
-	b.repo.Path = path
-	return b
-}
-
-func (b *testRepositoryBuilder) RemoteURL(remoteURL string) *testRepositoryBuilder {
-	b.repo.RemoteURL = remoteURL
-	return b
-}
-
-func (b *testRepositoryBuilder) Activity(activity domain.Activity) *testRepositoryBuilder {
-	b.repo.Activity = activity
-	return b
-}
-
-func (b *testRepositoryBuilder) LocalState(state domain.LocalState) *testRepositoryBuilder {
-	b.repo.LocalState = state
-	return b
-}
-
-func (b *testRepositoryBuilder) RemoteState(state domain.RemoteState) *testRepositoryBuilder {
-	b.repo.RemoteState = state
-	return b
-}
-
-func (b *testRepositoryBuilder) PullRequests(state domain.PullRequestState) *testRepositoryBuilder {
-	b.repo.PullRequests = state
-	return b
-}
-
-func (b *testRepositoryBuilder) CurrentBranch(branch domain.Branch) *testRepositoryBuilder {
-	b.repo.Branches.Current = branch
-	return b
-}
-
-func (b *testRepositoryBuilder) MergedBranches(merged ...string) *testRepositoryBuilder {
-	b.repo.Branches.Merged = append([]string(nil), merged...)
-	return b
-}
-
-func (b *testRepositoryBuilder) StashCount(count int) *testRepositoryBuilder {
-	b.repo.StashCount = count
-	return b
-}
-
-func (b *testRepositoryBuilder) Build() domain.Repository {
-	return b.repo
+	return testhelpers.NewTestRepository(name)
 }

--- a/internal/ui/views/listing/test_helpers_test.go
+++ b/internal/ui/views/listing/test_helpers_test.go
@@ -1,78 +1,16 @@
 package listing
 
-import "fresh/internal/domain"
+import (
+	"fresh/internal/domain"
+	"fresh/internal/testhelpers"
+)
+
+type testRepositoryBuilder = testhelpers.RepositoryBuilder
 
 func makeTestRepository(name string) domain.Repository {
 	return newTestRepository(name).Build()
 }
 
-type testRepositoryBuilder struct {
-	repo domain.Repository
-}
-
 func newTestRepository(name string) *testRepositoryBuilder {
-	return &testRepositoryBuilder{
-		repo: domain.Repository{
-			Name:        name,
-			Path:        "/tmp/" + name,
-			Activity:    domain.IdleActivity{},
-			LocalState:  domain.CleanLocalState{},
-			RemoteState: domain.Synced{},
-			Branches:    domain.Branches{Current: domain.OnBranch{Name: "main"}},
-		},
-	}
-}
-
-func (b *testRepositoryBuilder) Name(name string) *testRepositoryBuilder {
-	b.repo.Name = name
-	return b
-}
-
-func (b *testRepositoryBuilder) Path(path string) *testRepositoryBuilder {
-	b.repo.Path = path
-	return b
-}
-
-func (b *testRepositoryBuilder) RemoteURL(remoteURL string) *testRepositoryBuilder {
-	b.repo.RemoteURL = remoteURL
-	return b
-}
-
-func (b *testRepositoryBuilder) Activity(activity domain.Activity) *testRepositoryBuilder {
-	b.repo.Activity = activity
-	return b
-}
-
-func (b *testRepositoryBuilder) LocalState(state domain.LocalState) *testRepositoryBuilder {
-	b.repo.LocalState = state
-	return b
-}
-
-func (b *testRepositoryBuilder) RemoteState(state domain.RemoteState) *testRepositoryBuilder {
-	b.repo.RemoteState = state
-	return b
-}
-
-func (b *testRepositoryBuilder) PullRequests(state domain.PullRequestState) *testRepositoryBuilder {
-	b.repo.PullRequests = state
-	return b
-}
-
-func (b *testRepositoryBuilder) CurrentBranch(branch domain.Branch) *testRepositoryBuilder {
-	b.repo.Branches.Current = branch
-	return b
-}
-
-func (b *testRepositoryBuilder) MergedBranches(merged ...string) *testRepositoryBuilder {
-	b.repo.Branches.Merged = append([]string(nil), merged...)
-	return b
-}
-
-func (b *testRepositoryBuilder) StashCount(count int) *testRepositoryBuilder {
-	b.repo.StashCount = count
-	return b
-}
-
-func (b *testRepositoryBuilder) Build() domain.Repository {
-	return b.repo
+	return testhelpers.NewTestRepository(name)
 }


### PR DESCRIPTION
## Summary
- extract the duplicated test repository builder into shared `internal/testhelpers`
- keep existing test call sites stable via thin package-local wrappers

## Testing
- mise x -- go test ./...