### PR TITLE
Cache GitHub login in-memory with 1 hour TTL

### DIFF
--- a/internal/git/pull_request_details.go
+++ b/internal/git/pull_request_details.go
@@ -6,10 +6,22 @@ import (
 	"fresh/internal/domain"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
 var ErrPullRequestDetailsUnsupported = errors.New("pull requests are currently only supported for GitHub repositories")
+
+const githubLoginCacheTTL = time.Hour
+
+var cachedGitHubLogin githubLoginCache
+
+type githubLoginCache struct {
+	mu          sync.Mutex
+	login       string
+	expiresAt   time.Time
+	initialized bool
+}
 
 type ghRepoPullRequestRow struct {
 	Number            int                    `json:"number"`
@@ -80,12 +92,32 @@ func GetRepositoryPullRequests(repo domain.Repository) ([]domain.PullRequestDeta
 }
 
 func queryGitHubLogin() string {
-	cmd := createCommand(defaultConfig.Timeout.Default, "gh", "api", "user", "--jq", ".login")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
+	return cachedGitHubLogin.get(time.Now(), githubLoginCacheTTL, func() (string, error) {
+		cmd := createCommand(defaultConfig.Timeout.Default, "gh", "api", "user", "--jq", ".login")
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(output)), nil
+	})
+}
+
+func (c *githubLoginCache) get(now time.Time, ttl time.Duration, loader func() (string, error)) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.initialized && now.Before(c.expiresAt) {
+		return c.login
 	}
-	return strings.TrimSpace(string(output))
+
+	login, err := loader()
+	if err != nil {
+		login = ""
+	}
+	c.login = strings.TrimSpace(login)
+	c.expiresAt = now.Add(ttl)
+	c.initialized = true
+	return c.login
 }
 
 func summarizePullRequestChecks(contexts []ghStatusCheckContext) domain.PullRequestChecks {

--- a/internal/git/pull_request_details_test.go
+++ b/internal/git/pull_request_details_test.go
@@ -1,6 +1,10 @@
 package git
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+)
 
 func TestClassifyCheckContext(t *testing.T) {
 	t.Parallel()
@@ -86,5 +90,86 @@ func TestSummarizePullRequestChecks(t *testing.T) {
 	}
 	if summary.Skipped != 1 {
 		t.Fatalf("skipped = %d, want 1", summary.Skipped)
+	}
+}
+
+func TestGitHubLoginCacheGet_UsesCachedValueWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	var cache githubLoginCache
+	now := time.Date(2026, time.January, 2, 10, 0, 0, 0, time.UTC)
+	loadCalls := 0
+
+	loader := func() (string, error) {
+		loadCalls++
+		return "octocat\n", nil
+	}
+
+	first := cache.get(now, time.Hour, loader)
+	second := cache.get(now.Add(30*time.Minute), time.Hour, loader)
+
+	if first != "octocat" {
+		t.Fatalf("first = %q, want %q", first, "octocat")
+	}
+	if second != "octocat" {
+		t.Fatalf("second = %q, want %q", second, "octocat")
+	}
+	if loadCalls != 1 {
+		t.Fatalf("loader calls = %d, want 1", loadCalls)
+	}
+}
+
+func TestGitHubLoginCacheGet_RefreshesAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	var cache githubLoginCache
+	now := time.Date(2026, time.January, 2, 10, 0, 0, 0, time.UTC)
+	loadCalls := 0
+
+	loader := func() (string, error) {
+		loadCalls++
+		if loadCalls == 1 {
+			return "octocat", nil
+		}
+		return "monalisa", nil
+	}
+
+	first := cache.get(now, time.Hour, loader)
+	second := cache.get(now.Add(61*time.Minute), time.Hour, loader)
+
+	if first != "octocat" {
+		t.Fatalf("first = %q, want %q", first, "octocat")
+	}
+	if second != "monalisa" {
+		t.Fatalf("second = %q, want %q", second, "monalisa")
+	}
+	if loadCalls != 2 {
+		t.Fatalf("loader calls = %d, want 2", loadCalls)
+	}
+}
+
+func TestGitHubLoginCacheGet_CachesEmptyValueOnLoaderError(t *testing.T) {
+	t.Parallel()
+
+	var cache githubLoginCache
+	now := time.Date(2026, time.January, 2, 10, 0, 0, 0, time.UTC)
+	loadCalls := 0
+
+	loader := func() (string, error) {
+		loadCalls++
+		return "", errors.New("boom")
+	}
+
+	first := cache.get(now, time.Hour, loader)
+	second := cache.get(now.Add(30*time.Minute), time.Hour, loader)
+
+	if first != "" {
+		t.Fatalf("first = %q, want empty", first)
+	}
+	if second != "" {
+		t.Fatalf("second = %q, want empty", second)
+	}
+	if loadCalls != 1 {
+		t.Fatalf("loader calls = %d, want 1", loadCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- add an in-memory GitHub login cache with a 1 hour TTL for PR detail loads
- keep cache process-local (no cross-restart persistence)
- add unit tests for cache hit, TTL refresh, and error caching behavior

## Testing
- go test ./...
