### PR TITLE
Unify repository refresh pipeline

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,6 +16,44 @@ import (
 
 var defaultConfig = config.DefaultConfig()
 
+type RefreshMode int
+
+const (
+	RefreshModeBuildOnly RefreshMode = iota + 1
+	RefreshModeFetchRemoteOnly
+	RefreshModeFetchAndBuild
+)
+
+type RefreshRepositoryOptions struct {
+	Mode     RefreshMode
+	Existing *domain.Repository
+}
+
+func RefreshRepository(path string, cfg *config.Config, opts RefreshRepositoryOptions) domain.Repository {
+	switch opts.Mode {
+	case RefreshModeBuildOnly:
+		return BuildRepository(path, cfg)
+
+	case RefreshModeFetchRemoteOnly:
+		var repo domain.Repository
+		if opts.Existing != nil {
+			repo = *opts.Existing
+		} else {
+			repo = BuildRepository(path, cfg)
+		}
+
+		_ = RefreshRemoteStatusWithFetch(&repo)
+		return repo
+
+	case RefreshModeFetchAndBuild:
+		_ = Fetch(path)
+		return BuildRepository(path, cfg)
+
+	default:
+		return BuildRepository(path, cfg)
+	}
+}
+
 func createCommand(timeout time.Duration, name string, args ...string) *exec.Cmd {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	_ = cancel

--- a/internal/ui/views/listing/commands.go
+++ b/internal/ui/views/listing/commands.go
@@ -12,8 +12,10 @@ var cfg = config.DefaultConfig()
 
 func performInitialRefresh(index int, existingRepo domain.Repository) tea.Cmd {
 	return func() tea.Msg {
-		repo := existingRepo
-		_ = git.RefreshRemoteStatusWithFetch(&repo)
+		repo := git.RefreshRepository(existingRepo.Path, cfg, git.RefreshRepositoryOptions{
+			Mode:     git.RefreshModeFetchRemoteOnly,
+			Existing: &existingRepo,
+		})
 
 		return RepoUpdatedMsg{
 			Repo:  repo,
@@ -24,9 +26,9 @@ func performInitialRefresh(index int, existingRepo domain.Repository) tea.Cmd {
 
 func performRefresh(index int, repoPath string) tea.Cmd {
 	return func() tea.Msg {
-		// Fetch first, then build the repo to get fresh status (avoids 3x GetStatus calls)
-		git.Fetch(repoPath)
-		repo := git.BuildRepository(repoPath, cfg)
+		repo := git.RefreshRepository(repoPath, cfg, git.RefreshRepositoryOptions{
+			Mode: git.RefreshModeFetchAndBuild,
+		})
 
 		return RepoUpdatedMsg{
 			Repo:  repo,

--- a/internal/ui/views/scanning/scanning.go
+++ b/internal/ui/views/scanning/scanning.go
@@ -51,7 +51,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 
 	case repoFoundMsg:
 		path := string(msg)
-		repo := git.BuildRepository(path, cfg)
+		repo := git.RefreshRepository(path, cfg, git.RefreshRepositoryOptions{
+			Mode: git.RefreshModeBuildOnly,
+		})
 		m.Repositories = append(m.Repositories, repo)
 		return m, waitForRepo(m.scanner.GetRepoChannel())
 


### PR DESCRIPTION
## Summary
- introduce a single `git.RefreshRepository(...)` pipeline with explicit modes
- route scan, listing init refresh, and manual/watch refresh through the same entry point
- preserve existing behavior for each flow by mode:
  - scan: build-only (no fetch)
  - listing init: fetch + remote-state refresh on existing snapshot
  - manual/watch: fetch + full rebuild

## Verification
- `go test ./...` passes
- startup parity check:
  - scan still does one full build per repo
  - listing transition still does fetch + remote state update (no second full build)
  - manual/watch refresh still does fetch + full rebuild
