### PR TITLE
Style pull failure output and remove error prefix

### DIFF
--- a/internal/ui/views/listing/info_messages.go
+++ b/internal/ui/views/listing/info_messages.go
@@ -20,7 +20,13 @@ const (
 	InfoToneSuccess
 	InfoToneWarn
 	InfoToneError
+	InfoTonePullFailure
 	InfoTonePullRequestSummary
+)
+
+const (
+	pullFailedLabel = "Pull Failed"
+	errorPrefix     = "error:"
 )
 
 type InfoMessage struct {
@@ -167,9 +173,9 @@ func buildPullCompletionInfoMessage(activity domain.PullingActivity) InfoMessage
 	}
 
 	if !activity.Outcome.IsSuccess() {
-		reason := textutil.FirstNonEmptyTrimmed(activity.Outcome.FailureReason, activity.GetLastLine(), "pull failed")
+		reason := sanitizePullFailureReason(textutil.FirstNonEmptyTrimmed(activity.Outcome.FailureReason, activity.GetLastLine(), "pull failed"))
 		return InfoMessageResult{
-			Message: InfoMessage{Text: fmt.Sprintf("Pull failed: %s", reason), Tone: InfoToneWarn},
+			Message: InfoMessage{Text: reason, Tone: InfoTonePullFailure},
 			OK:      true,
 		}
 	}
@@ -212,22 +218,48 @@ func buildPruneCompletionInfoMessage(activity domain.PruningActivity) InfoMessag
 
 func renderInfoMessage(msg InfoMessage, infoWidth int) string {
 	infoWidth = normalizeInfoWidth(infoWidth)
-	text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 
 	switch msg.Tone {
 	case InfoTonePrimary:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return common.PullOutputUpToDate.Width(infoWidth).Render(text)
 	case InfoToneSuccess:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return common.PullOutputSuccess.Width(infoWidth).Render(text)
 	case InfoToneWarn:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return common.PullOutputWarn.Width(infoWidth).Render(text)
 	case InfoToneError:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return common.PullOutputError.Width(infoWidth).Render(text)
+	case InfoTonePullFailure:
+		return renderPullFailureInfoMessage(msg.Text, infoWidth)
 	case InfoTonePullRequestSummary:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return renderMyPullRequestSummaryInfo(text, infoWidth)
 	default:
+		text := common.TruncateWithEllipsis(msg.Text, infoWidth)
 		return common.TextGrey.Render(text)
 	}
+}
+
+func sanitizePullFailureReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if len(reason) >= len(errorPrefix) && strings.EqualFold(reason[:len(errorPrefix)], errorPrefix) {
+		reason = strings.TrimSpace(reason[len(errorPrefix):])
+	}
+	return textutil.FirstNonEmptyTrimmed(reason, "pull failed")
+}
+
+func renderPullFailureInfoMessage(reason string, infoWidth int) string {
+	full := common.TruncateWithEllipsis(fmt.Sprintf("%s: %s", pullFailedLabel, reason), infoWidth)
+	if !strings.HasPrefix(full, pullFailedLabel) || len(full) <= len(pullFailedLabel) {
+		return common.PullOutputError.Width(infoWidth).Render(full)
+	}
+
+	label := common.PullOutputError.Render(pullFailedLabel)
+	detail := common.PullOutputUpToDate.Render(full[len(pullFailedLabel):])
+	return common.InfoStyle.Width(infoWidth).MaxWidth(infoWidth).Render(label + detail)
 }
 
 func renderMyPullRequestSummaryInfo(text string, infoWidth int) string {

--- a/internal/ui/views/listing/info_messages_test.go
+++ b/internal/ui/views/listing/info_messages_test.go
@@ -1,0 +1,74 @@
+package listing
+
+import (
+	"strings"
+	"testing"
+
+	"fresh/internal/domain"
+	"fresh/internal/ui/views/common"
+)
+
+func TestBuildPullCompletionInfoMessage_FailureStripsErrorPrefix(t *testing.T) {
+	t.Parallel()
+
+	activity := domain.PullingActivity{
+		CommandCompletion: domain.CommandCompletion{
+			Complete: true,
+			Outcome: domain.CommandOutcome{
+				ExitCode:      1,
+				FailureReason: "error: cannot fast-forward",
+			},
+		},
+	}
+
+	result := buildPullCompletionInfoMessage(activity)
+	if !result.OK {
+		t.Fatal("buildPullCompletionInfoMessage() expected OK result")
+	}
+	if result.Message.Tone != InfoTonePullFailure {
+		t.Fatalf("buildPullCompletionInfoMessage() tone = %v, want %v", result.Message.Tone, InfoTonePullFailure)
+	}
+	if result.Message.Text != "cannot fast-forward" {
+		t.Fatalf("buildPullCompletionInfoMessage() text = %q, want %q", result.Message.Text, "cannot fast-forward")
+	}
+}
+
+func TestBuildPullCompletionInfoMessage_FailureStripsErrorPrefixFromLastLine(t *testing.T) {
+	t.Parallel()
+
+	activity := domain.PullingActivity{
+		LineBuffer: domain.LineBuffer{
+			Lines: []string{"some progress", "Error: remote rejected"},
+		},
+		CommandCompletion: domain.CommandCompletion{
+			Complete: true,
+			Outcome: domain.CommandOutcome{
+				ExitCode: 1,
+			},
+		},
+	}
+
+	result := buildPullCompletionInfoMessage(activity)
+	if result.Message.Text != "remote rejected" {
+		t.Fatalf("buildPullCompletionInfoMessage() text = %q, want %q", result.Message.Text, "remote rejected")
+	}
+}
+
+func TestRenderInfoMessage_PullFailureUsesRedLabelAndWhiteDetail(t *testing.T) {
+	t.Parallel()
+
+	got := renderInfoMessage(InfoMessage{
+		Text: "cannot fast-forward",
+		Tone: InfoTonePullFailure,
+	}, 80)
+
+	wantLabel := common.PullOutputError.Render(pullFailedLabel)
+	if !strings.Contains(got, wantLabel) {
+		t.Fatalf("renderInfoMessage() = %q, want red label fragment %q", got, wantLabel)
+	}
+
+	wantDetail := common.PullOutputUpToDate.Render(": cannot fast-forward")
+	if !strings.Contains(got, wantDetail) {
+		t.Fatalf("renderInfoMessage() = %q, want white detail fragment %q", got, wantDetail)
+	}
+}


### PR DESCRIPTION
## Summary
- render pull failure messages with a red 'Pull Failed' label and white detail text
- strip a leading 'error:' prefix from pull failure reasons (case-insensitive)
- add tests for failure reason sanitization and red/white pull-failure rendering

## Testing
- go test ./internal/ui/views/listing
- go test ./...